### PR TITLE
[release-@brain-toolkit/antd-theme-override-0.0.3 Release] Branch:master, Tag:0.0.3, Env:production

### DIFF
--- a/packages/antd-theme-override/CHANGELOG.md
+++ b/packages/antd-theme-override/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @brain-toolkit/antd-theme-override
 
+## 0.0.3
+
+### Patch Changes
+
+#### 🐞 Bug Fixes
+
+- **antd-theme-override:** Add helper function for directory resolution ([dcc2f16](https://github.com/qlover/brain-toolkit/commit/dcc2f16a518dec6a53d04162eb77c27d6902b14e)) ([#15](https://github.com/qlover/brain-toolkit/pull/15))
+
+  - Introduced a `getDirname` function to handle directory resolution for both ESM and CJS environments, improving compatibility across different module systems.
+  - Updated the `templatePath` resolution in the Vite plugin to utilize the new helper function, ensuring correct path handling regardless of the module type.
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/antd-theme-override/package.json
+++ b/packages/antd-theme-override/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brain-toolkit/antd-theme-override",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "private": false,
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: 0.0.3
- 🌲 Branch: master
- 🔧 Environment: production

## Changelog

#### 🐞 Bug Fixes

- **antd-theme-override:** Add helper function for directory resolution ([dcc2f16](https://github.com/qlover/brain-toolkit/commit/dcc2f16a518dec6a53d04162eb77c27d6902b14e)) ([#15](https://github.com/qlover/brain-toolkit/pull/15))
  
  
  - Introduced a `getDirname` function to handle directory resolution for both ESM and CJS environments, improving compatibility across different module systems.
  - Updated the `templatePath` resolution in the Vite plugin to utilize the new helper function, ensuring correct path handling regardless of the module type.

## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.