### PR TITLE
[batch-@brain-toolkit/antd-blocks@0.1.3_@brain-toolkit/antd-theme-override@0.1.2_@brain-toolkit/brain-user@0.2.2-5-packages-1773304137855 Release] Branch:master, Tag:batch-5-packages-1773304137855, Env:production

### DIFF
--- a/examples/brain-user/CHANGELOG.md
+++ b/examples/brain-user/CHANGELOG.md
@@ -1,5 +1,17 @@
 # examples/brain-user
 
+## 0.2.1
+
+### Patch Changes
+
+#### ♻️ Refactors
+
+- Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
+  - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
+  - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
+  - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
+  - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/examples/brain-user/package.json
+++ b/examples/brain-user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples/brain-user",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/antd-blocks/CHANGELOG.md
+++ b/packages/antd-blocks/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @brain-toolkit/antd-blocks
 
+## 0.1.3
+
+### Patch Changes
+
+#### ♻️ Refactors
+
+- Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
+  - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
+  - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
+  - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
+  - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/antd-blocks/package.json
+++ b/packages/antd-blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brain-toolkit/antd-blocks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "private": false,
   "main": "./dist/index.cjs",

--- a/packages/antd-theme-override/CHANGELOG.md
+++ b/packages/antd-theme-override/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @brain-toolkit/antd-theme-override
 
+## 0.1.2
+
+### Patch Changes
+
+#### ♻️ Refactors
+
+- Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
+  - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
+  - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
+  - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
+  - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/antd-theme-override/package.json
+++ b/packages/antd-theme-override/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brain-toolkit/antd-theme-override",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "private": false,
   "main": "./dist/index.cjs",

--- a/packages/brain-user/CHANGELOG.md
+++ b/packages/brain-user/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @brain-toolkit/brain-user
 
+## 0.2.2
+
+### Patch Changes
+
+#### ♻️ Refactors
+
+- Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
+  - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
+  - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
+  - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
+  - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/brain-user/package.json
+++ b/packages/brain-user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brain-toolkit/brain-user",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "private": false,
   "main": "./dist/index.cjs",

--- a/packages/react-kit/CHANGELOG.md
+++ b/packages/react-kit/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @brain-toolkit/react-kit
 
+## 0.2.3
+
+### Patch Changes
+
+#### ♻️ Refactors
+
+- Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
+  - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
+  - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
+  - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
+  - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brain-toolkit/react-kit",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "private": false,
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Publish Details

- 🏷️ Version: @brain-toolkit/antd-blocks@0.1.3 @brain-toolkit/antd-theme-override@0.1.2 @brain-toolkit/brain-user@0.2.2 @brain-toolkit/react-kit@0.2.3 examples/brain-user@0.2.1
- 🌲 Branch: master
- 🔧 Environment: production

## Changelog


## @brain-toolkit/antd-blocks 0.1.3
#### ♻️ Refactors

-  Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
    
    
    - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
    - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
    - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
    - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.


## @brain-toolkit/antd-theme-override 0.1.2
#### ♻️ Refactors

-  Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
    
    
    - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
    - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
    - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
    - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.


## @brain-toolkit/brain-user 0.2.2
#### ♻️ Refactors

-  Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
    
    
    - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
    - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
    - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
    - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.


## @brain-toolkit/react-kit 0.2.3
#### ♻️ Refactors

-  Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
    
    
    - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
    - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
    - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
    - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.


## examples/brain-user 0.2.1
#### ♻️ Refactors

-  Update package dependencies for @qlover/corekit-bridge, @qlover/fe-corekit, and @qlover/slice-store-react ([8663165](https://github.com/qlover/brain-toolkit/commit/8663165afa9880e1a66821ed727238abe6ae78cd)) ([#37](https://github.com/qlover/brain-toolkit/pull/37))
    
    
    - Changed version specifiers for @qlover/corekit-bridge and @qlover/fe-corekit to use major version ranges.
    - Upgraded @qlover/slice-store-react from version 1.4.1 to 1.4.2 across multiple package.json files.
    - Added peerDependencies for react and antd in relevant packages to ensure compatibility with version 18.0.0 and above.
    - Updated pnpm-lock.yaml to reflect these changes and maintain consistency across the project.


## Notes

- [ ] Please check if the version number is correct
- [ ] Please confirm all tests have passed
- [ ] Please confirm the documentation has been updated

> This PR is auto created by release process, please contact the frontend team if there are any questions.