### PR TITLE
feat(brain-oauth): Implement OAuth authorization flow with consent handling

### DIFF
--- a/examples/brain-oauth/docs/oauth-authorize-prototype.html
+++ b/examples/brain-oauth/docs/oauth-authorize-prototype.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>授权确认 - Brain OAuth</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;500;600;700&display=swap"
+    rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+      transition: all 0.2s;
+    }
+
+    .dark {
+      background-color: #0f172a;
+      color: #e2e8f0;
+    }
+
+    .light {
+      background-color: #f1f5f9;
+      color: #0f172a;
+    }
+
+    .toggle-checkbox:checked {
+      right: 0;
+      border-color: #4f46e5;
+    }
+
+    .toggle-checkbox:checked+.toggle-label {
+      background-color: #4f46e5;
+    }
+  </style>
+</head>
+
+<body class="light">
+  <div class="min-h-screen flex flex-col">
+    <!-- 导航栏（同前，略） -->
+    <nav
+      class="sticky top-0 z-50 backdrop-blur-md bg-opacity-80 light:bg-white/80 dark:bg-gray-900/80 border-b light:border-gray-200 dark:border-gray-800">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center space-x-2">
+            <i class="fas fa-brain text-2xl text-indigo-600"></i>
+            <span class="font-bold text-xl">Brain OAuth</span>
+          </div>
+          <div class="flex items-center space-x-3">
+            <button id="themeToggle" class="p-2 rounded-full light:bg-gray-100 dark:bg-gray-800"><i id="themeIcon"
+                class="fas fa-moon"></i></button>
+            <div class="relative">
+              <button id="langToggle"
+                class="flex items-center space-x-1 px-3 py-1.5 rounded-lg light:bg-gray-100 text-sm"><i
+                  class="fas fa-globe"></i><span id="currentLangLabel">中文</span></button>
+              <div id="langMenu"
+                class="hidden absolute right-0 mt-2 w-24 rounded-lg shadow-lg light:bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5">
+                <button data-lang="zh"
+                  class="lang-option block w-full text-left px-4 py-2 text-sm hover:bg-indigo-50">中文</button>
+                <button data-lang="en"
+                  class="lang-option block w-full text-left px-4 py-2 text-sm hover:bg-indigo-50">English</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="flex-1 flex items-center justify-center px-4 py-12">
+      <div
+        class="max-w-lg w-full bg-white dark:bg-gray-800 rounded-2xl shadow-xl border light:border-gray-200 dark:border-gray-700 overflow-hidden">
+        <!-- 错误提示区域 -->
+        <div id="errorAlert"
+          class="hidden mx-6 mt-4 bg-red-50 dark:bg-red-900/30 border-l-4 border-red-500 p-3 rounded text-sm text-red-700 dark:text-red-300">
+          <i class="fas fa-exclamation-triangle mr-2"></i><span id="errorMsg"></span>
+        </div>
+
+        <div class="p-6 border-b light:border-gray-200 dark:border-gray-700">
+          <div class="flex items-center gap-3">
+            <div id="appLogo"
+              class="w-12 h-12 rounded-full bg-indigo-100 dark:bg-indigo-900/50 flex items-center justify-center text-indigo-600 text-xl">
+              <i class="fas fa-apple-alt"></i>
+            </div>
+            <div>
+              <h2 class="text-xl font-semibold" data-i18n="title">授权请求</h2>
+              <p class="text-sm text-gray-500 dark:text-gray-400" data-i18n="subtitle">正在请求访问您的账户</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-6 space-y-5">
+          <!-- 应用信息块 -->
+          <div class="bg-gray-50 dark:bg-gray-900/50 rounded-lg p-4">
+            <div class="flex justify-between items-start">
+              <div>
+                <p class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide" data-i18n="app_name_label">
+                  应用名称</p>
+                <p id="appName" class="font-semibold text-lg">Demo App</p>
+                <p id="appDesc" class="text-sm text-gray-500 dark:text-gray-400">示例应用描述</p>
+              </div>
+              <span
+                class="bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 text-xs px-2 py-1 rounded-full">OAuth
+                2.0</span>
+            </div>
+          </div>
+
+          <!-- 权限区域 + 可折叠详情 -->
+          <div>
+            <div class="flex justify-between items-center cursor-pointer" id="togglePerms">
+              <p class="text-sm font-medium flex items-center gap-1"><i class="fas fa-lock"></i> <span
+                  data-i18n="permissions_label">请求的权限</span></p>
+              <i id="chevron" class="fas fa-chevron-down text-gray-400 transition-transform"></i>
+            </div>
+            <div id="permList" class="mt-2 space-y-2 pl-1">
+              <div class="flex items-start gap-2"><i class="fas fa-check-circle text-green-500 text-sm mt-0.5"></i>
+                <span data-i18n="perm_openid">使用您的身份信息登录</span></div>
+              <div class="flex items-start gap-2"><i class="fas fa-check-circle text-green-500 text-sm mt-0.5"></i>
+                <span data-i18n="perm_email">查看您的电子邮件地址</span></div>
+              <div class="flex items-start gap-2"><i class="fas fa-check-circle text-green-500 text-sm mt-0.5"></i>
+                <span data-i18n="perm_profile">查看您的公开个人资料（姓名、头像）</span></div>
+            </div>
+            <!-- 可折叠的额外说明 -->
+            <div id="extraPerms"
+              class="hidden mt-2 pl-5 text-xs text-gray-500 dark:text-gray-400 border-l-2 border-indigo-300">
+              <p data-i18n="extra_perm_note">该应用不会获取您的密码，仅访问您已同意的信息。</p>
+            </div>
+          </div>
+
+          <!-- 高级选项：信任此应用 -->
+          <div class="flex items-center justify-between pt-2">
+            <div class="flex items-center">
+              <input type="checkbox" id="trustCheckbox" class="w-4 h-4 text-indigo-600 rounded focus:ring-indigo-500">
+              <label for="trustCheckbox" class="ml-2 text-sm text-gray-700 dark:text-gray-300"
+                data-i18n="trust_option">信任此应用，以后不再询问</label>
+            </div>
+            <i class="fas fa-question-circle text-gray-400 text-xs cursor-pointer"
+              title="您将直接授权该应用，无需再次确认。可在开发者控制台撤销。"></i>
+          </div>
+
+          <!-- 安全提示 -->
+          <div class="bg-amber-50 dark:bg-amber-950/30 border-l-4 border-amber-500 p-3 rounded text-sm">
+            <i class="fas fa-info-circle text-amber-600 mr-2"></i>
+            <span data-i18n="safety_note">仅授权您信任的应用。您可以随时在账号设置中撤销授权。</span>
+          </div>
+        </div>
+
+        <div class="p-6 border-t bg-gray-50 dark:bg-gray-900/30 flex flex-col sm:flex-row gap-3">
+          <button id="denyBtn"
+            class="flex-1 px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 transition font-medium">
+            <span data-i18n="deny">拒绝</span>
+          </button>
+          <button id="allowBtn"
+            class="flex-1 px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition font-medium shadow-sm flex items-center justify-center gap-2">
+            <span data-i18n="allow">同意授权</span>
+            <i id="allowSpinner" class="fas fa-spinner fa-spin hidden"></i>
+          </button>
+        </div>
+      </div>
+    </main>
+
+    <footer class="text-center text-sm text-gray-500 py-6 border-t light:border-gray-200 dark:border-gray-800">
+      <p>© 2026 Brain OAuth · 安全身份验证服务</p>
+    </footer>
+  </div>
+
+  <script>
+    // 模拟从 URL 获取数据 (实际服务端渲染注入)
+    const app = { name: "示例应用", description: "用于测试 OAuth 流程的演示应用", logo: null };
+    document.getElementById('appName').innerText = app.name;
+    document.getElementById('appDesc').innerText = app.description;
+
+    // 国际化
+    const translations = {
+      zh: { title: "授权请求", subtitle: "正在请求访问您的账户", app_name_label: "应用名称", permissions_label: "请求的权限", perm_openid: "使用您的身份信息登录", perm_email: "查看您的电子邮件地址", perm_profile: "查看您的公开个人资料（姓名、头像）", extra_perm_note: "该应用不会获取您的密码，仅访问您已同意的信息。", trust_option: "信任此应用，以后不再询问", safety_note: "仅授权您信任的应用。您可以随时在账号设置中撤销授权。", deny: "拒绝", allow: "同意授权" },
+      en: { title: "Authorization Request", subtitle: "is requesting access to your account", app_name_label: "Application", permissions_label: "Requested permissions", perm_openid: "Authenticate using your identity", perm_email: "View your email address", perm_profile: "View your public profile (name, avatar)", extra_perm_note: "This app will never see your password.", trust_option: "Trust this app and do not ask again", safety_note: "Only authorize apps you trust. You can revoke access anytime.", deny: "Deny", allow: "Allow" }
+    };
+    let currentLang = localStorage.getItem('lang') || 'zh';
+    let currentTheme = localStorage.getItem('theme') || 'light';
+
+    function applyLang(lang) {
+      document.querySelectorAll('[data-i18n]').forEach(el => {
+        const key = el.getAttribute('data-i18n');
+        if (translations[lang][key]) el.innerText = translations[lang][key];
+      });
+      document.getElementById('currentLangLabel').innerText = lang === 'zh' ? '中文' : 'English';
+      localStorage.setItem('lang', lang);
+    }
+    function applyTheme(theme) {
+      document.body.classList.remove('light', 'dark');
+      document.body.classList.add(theme);
+      const icon = document.getElementById('themeIcon');
+      icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+      localStorage.setItem('theme', theme);
+    }
+    // 初始化
+    applyTheme(currentTheme);
+    applyLang(currentLang);
+    document.getElementById('themeToggle').addEventListener('click', () => {
+      applyTheme(document.body.classList.contains('dark') ? 'light' : 'dark');
+    });
+    const langBtn = document.getElementById('langToggle'), langMenu = document.getElementById('langMenu');
+    langBtn.addEventListener('click', (e) => { e.stopPropagation(); langMenu.classList.toggle('hidden'); });
+    document.querySelectorAll('.lang-option').forEach(btn => {
+      btn.addEventListener('click', () => { applyLang(btn.getAttribute('data-lang')); langMenu.classList.add('hidden'); });
+    });
+    document.addEventListener('click', () => langMenu.classList.add('hidden'));
+
+    // 可折叠权限详情
+    const togglePerms = document.getElementById('togglePerms');
+    const extraPerms = document.getElementById('extraPerms');
+    const chevron = document.getElementById('chevron');
+    togglePerms.addEventListener('click', () => {
+      extraPerms.classList.toggle('hidden');
+      chevron.classList.toggle('rotate-180');
+    });
+
+    // 模拟同意/拒绝 (带加载状态)
+    const allowBtn = document.getElementById('allowBtn');
+    const denyBtn = document.getElementById('denyBtn');
+    const spinner = document.getElementById('allowSpinner');
+    const errorDiv = document.getElementById('errorAlert');
+    const errorMsg = document.getElementById('errorMsg');
+
+    async function handleAllow() {
+      allowBtn.disabled = true;
+      spinner.classList.remove('hidden');
+      errorDiv.classList.add('hidden');
+      // 模拟异步请求 (调用 /api/oauth/consent)
+      setTimeout(() => {
+        const trust = document.getElementById('trustCheckbox').checked;
+        console.log(trust ? "后续自动授权" : "单次授权");
+        // 实际开发中应发送 POST
+        alert("演示模式：将生成授权码并重定向到 redirect_uri");
+        allowBtn.disabled = false;
+        spinner.classList.add('hidden');
+      }, 800);
+    }
+    function handleDeny() {
+      if (confirm("拒绝授权将导致第三方应用无法访问您的信息。确定拒绝？")) {
+        alert("已拒绝授权，将返回错误给第三方应用");
+        // 实际应重定向并带 error=access_denied
+      }
+    }
+    allowBtn.addEventListener('click', handleAllow);
+    denyBtn.addEventListener('click', handleDeny);
+  </script>
+</body>
+
+</html>

--- a/examples/brain-oauth/server/controllers/OAuthConsentController.ts
+++ b/examples/brain-oauth/server/controllers/OAuthConsentController.ts
@@ -1,0 +1,20 @@
+import { inject, injectable } from '@shared/container';
+import { OAuthConsentService } from '../services/OAuthConsentService';
+import type { OAuthConsentResult } from '../services/OAuthConsentService';
+
+/**
+ * HTTP entry for OAuth user consent (`POST /api/oauth/consent`).
+ */
+@injectable()
+export class OAuthConsentController {
+  constructor(
+    @inject(OAuthConsentService)
+    protected consentService: OAuthConsentService
+  ) {}
+
+  public async submitConsent(
+    requestBody: unknown
+  ): Promise<OAuthConsentResult> {
+    return await this.consentService.processConsent(requestBody);
+  }
+}

--- a/examples/brain-oauth/server/repositorys/OAuthAuthorizationCodesRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthAuthorizationCodesRepository.ts
@@ -1,0 +1,34 @@
+import { injectable } from '@shared/container';
+import { createAdminClient } from '@shared/supabase/admin';
+
+export type CreateAuthorizationCodeInput = {
+  code: string;
+  client_id: string;
+  user_id: number;
+  redirect_uri: string;
+  scope: string | null;
+  expires_at: string;
+};
+
+/**
+ * Persists one-time OAuth authorization codes.
+ */
+@injectable()
+export class OAuthAuthorizationCodesRepository {
+  public async create(input: CreateAuthorizationCodeInput): Promise<void> {
+    const supabase = createAdminClient();
+    const { error } = await supabase.from('brain_oauth_authorization_codes').insert({
+      code: input.code,
+      client_id: input.client_id,
+      user_id: input.user_id,
+      redirect_uri: input.redirect_uri,
+      scope: input.scope,
+      expires_at: input.expires_at,
+      used: false
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+}

--- a/examples/brain-oauth/server/repositorys/OAuthClientsRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthClientsRepository.ts
@@ -1,0 +1,24 @@
+import { injectable } from '@shared/container';
+import { createAdminClient } from '@shared/supabase/admin';
+import type { OAuthClientRow } from '@schemas/oauth/OAuthAuthorizeSchema';
+
+/**
+ * Reads registered OAuth clients from Supabase (service role).
+ */
+@injectable()
+export class OAuthClientsRepository {
+  public async findByClientId(clientId: string): Promise<OAuthClientRow | null> {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from('brain_oauth_clients')
+      .select('*')
+      .eq('client_id', clientId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return (data as OAuthClientRow | null) ?? null;
+  }
+}

--- a/examples/brain-oauth/server/services/OAuthAuthorizeService.ts
+++ b/examples/brain-oauth/server/services/OAuthAuthorizeService.ts
@@ -1,0 +1,149 @@
+import { inject, injectable } from '@shared/container';
+import { OAuthClientsRepository } from '../repositorys/OAuthClientsRepository';
+import {
+  OAuthAuthorizeQueryValidator
+} from '@shared/validators/OAuthAuthorizeValidator';
+import { parseScopeList } from '../utils/oauthRedirectUtils';
+import type { OAuthClientRow } from '@schemas/oauth/OAuthAuthorizeSchema';
+
+export type OAuthAuthorizePageData = {
+  clientId: string;
+  clientName: string;
+  clientUri: string | null;
+  logoUri: string | null;
+  redirectUri: string;
+  scopes: string[];
+  state?: string;
+  responseType: 'code';
+};
+
+export type OAuthAuthorizeValidationError = {
+  errorKey: string;
+  message: string;
+};
+
+/**
+ * Validates OAuth authorize query params and loads client metadata for the consent page.
+ *
+ * Significance: Server-side gate before rendering the authorize UI.
+ * Main purpose: Enforce OAuth 2.0 parameter and client registration rules.
+ *
+ * @example
+ * const page = await service.resolveAuthorizePage(searchParams);
+ */
+@injectable()
+export class OAuthAuthorizeService {
+  constructor(
+    @inject(OAuthClientsRepository)
+    protected clientsRepo: OAuthClientsRepository,
+    @inject(OAuthAuthorizeQueryValidator)
+    protected queryValidator: OAuthAuthorizeQueryValidator
+  ) {}
+
+  public async resolveAuthorizePage(
+    rawQuery: Record<string, string | string[] | undefined>
+  ): Promise<
+    { ok: true; data: OAuthAuthorizePageData } | { ok: false; error: OAuthAuthorizeValidationError }
+  > {
+    const query = this.normalizeQuery(rawQuery);
+
+    let parsed;
+    try {
+      parsed = await this.queryValidator.getThrow(query);
+    } catch {
+      return {
+        ok: false,
+        error: {
+          errorKey: 'invalid_request',
+          message: 'Missing or invalid authorization request parameters.'
+        }
+      };
+    }
+
+    if (parsed.response_type !== 'code') {
+      return {
+        ok: false,
+        error: {
+          errorKey: 'unsupported_response_type',
+          message: 'Only response_type=code is supported.'
+        }
+      };
+    }
+
+    const client = await this.clientsRepo.findByClientId(parsed.client_id);
+    if (!client) {
+      return {
+        ok: false,
+        error: {
+          errorKey: 'unauthorized_client',
+          message: 'Unknown client_id.'
+        }
+      };
+    }
+
+    if (!this.isRedirectUriAllowed(parsed.redirect_uri, client)) {
+      return {
+        ok: false,
+        error: {
+          errorKey: 'unauthorized_client',
+          message: 'redirect_uri is not registered for this client.'
+        }
+      };
+    }
+
+    const requestedScopes = parseScopeList(parsed.scope);
+    const invalidScope = requestedScopes.find(
+      (scope) => !client.scopes.includes(scope)
+    );
+    if (invalidScope) {
+      return {
+        ok: false,
+        error: {
+          errorKey: 'invalid_scope',
+          message: `Scope "${invalidScope}" is not allowed for this client.`
+        }
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        clientId: client.client_id,
+        clientName: client.client_name,
+        clientUri: client.client_uri ?? null,
+        logoUri: client.logo_uri ?? null,
+        redirectUri: parsed.redirect_uri,
+        scopes: requestedScopes,
+        state: parsed.state,
+        responseType: 'code'
+      }
+    };
+  }
+
+  protected normalizeQuery(
+    raw: Record<string, string | string[] | undefined>
+  ): Record<string, string | undefined> {
+    const result: Record<string, string | undefined> = {};
+
+    for (const [key, value] of Object.entries(raw)) {
+      if (Array.isArray(value)) {
+        result[key] = value[0];
+      } else {
+        result[key] = value;
+      }
+    }
+
+    if (!result.response_type) {
+      result.response_type = 'code';
+    }
+
+    return result;
+  }
+
+  protected isRedirectUriAllowed(
+    redirectUri: string,
+    client: OAuthClientRow
+  ): boolean {
+    return client.redirect_uris.includes(redirectUri);
+  }
+}

--- a/examples/brain-oauth/server/services/OAuthConsentService.ts
+++ b/examples/brain-oauth/server/services/OAuthConsentService.ts
@@ -1,0 +1,111 @@
+import { randomBytes } from 'crypto';
+import { ExecutorError } from '@qlover/fe-corekit';
+import { inject, injectable } from '@shared/container';
+import { OAuthAuthorizeService } from './OAuthAuthorizeService';
+import { OAuthAuthorizationCodesRepository } from '../repositorys/OAuthAuthorizationCodesRepository';
+import { BrainSessionService } from './BrainSessionService';
+import {
+  OAuthConsentBodyValidator
+} from '@shared/validators/OAuthAuthorizeValidator';
+import { buildOAuthRedirectUrl } from '../utils/oauthRedirectUtils';
+import type { OAuthConsentBody } from '@schemas/oauth/OAuthAuthorizeSchema';
+
+export type OAuthConsentResult = {
+  redirectUrl: string;
+};
+
+/**
+ * Handles user consent (allow/deny) on the OAuth authorize page.
+ *
+ * Significance: Bridges the consent UI to authorization code issuance.
+ * Main purpose: Issue one-time codes or redirect with OAuth error parameters.
+ *
+ * @example
+ * const result = await service.processConsent(body);
+ * // redirect browser to result.redirectUrl
+ */
+@injectable()
+export class OAuthConsentService {
+  protected static AUTH_CODE_TTL_MS = 5 * 60 * 1000;
+
+  constructor(
+    @inject(OAuthAuthorizeService)
+    protected authorizeService: OAuthAuthorizeService,
+    @inject(OAuthAuthorizationCodesRepository)
+    protected authCodesRepo: OAuthAuthorizationCodesRepository,
+    @inject(BrainSessionService)
+    protected brainSession: BrainSessionService,
+    @inject(OAuthConsentBodyValidator)
+    protected consentValidator: OAuthConsentBodyValidator
+  ) {}
+
+  public async processConsent(
+    requestBody: unknown
+  ): Promise<OAuthConsentResult> {
+    let body: OAuthConsentBody;
+    try {
+      body = await this.consentValidator.getThrow(requestBody);
+    } catch {
+      throw new ExecutorError(
+        'invalid_request',
+        'Invalid consent request body'
+      );
+    }
+
+    const session = await this.brainSession.getSession();
+    if (!session) {
+      throw new ExecutorError(
+        'access_denied',
+        'User session expired. Please sign in again.'
+      );
+    }
+
+    const pageResult = await this.authorizeService.resolveAuthorizePage({
+      response_type: 'code',
+      client_id: body.client_id,
+      redirect_uri: body.redirect_uri,
+      scope: body.scope,
+      state: body.state
+    });
+
+    if (!pageResult.ok) {
+      throw new ExecutorError(pageResult.error.errorKey, pageResult.error.message);
+    }
+
+    const { data } = pageResult;
+
+    if (body.action === 'deny') {
+      return {
+        redirectUrl: buildOAuthRedirectUrl(data.redirectUri, {
+          error: 'access_denied',
+          error_description: 'The resource owner denied the request',
+          state: data.state
+        })
+      };
+    }
+
+    const code = randomBytes(32).toString('base64url');
+    const expiresAt = new Date(
+      Date.now() + OAuthConsentService.AUTH_CODE_TTL_MS
+    ).toISOString();
+
+    await this.authCodesRepo.create({
+      code,
+      client_id: data.clientId,
+      user_id: session.userId,
+      redirect_uri: data.redirectUri,
+      scope: data.scopes.join(' ') || null,
+      expires_at: expiresAt
+    });
+
+    // trust flag reserved for future auto-consent storage
+    void body.trust;
+
+    return {
+      redirectUrl: buildOAuthRedirectUrl(data.redirectUri, {
+        code,
+        state: data.state
+      })
+    };
+  }
+}

--- a/examples/brain-oauth/server/utils/oauthRedirectUtils.ts
+++ b/examples/brain-oauth/server/utils/oauthRedirectUtils.ts
@@ -1,0 +1,28 @@
+/**
+ * Builds OAuth 2.0 redirect URLs for authorization responses.
+ */
+export function buildOAuthRedirectUrl(
+  redirectUri: string,
+  params: Record<string, string | undefined>
+): string {
+  const url = new URL(redirectUri);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null && value !== '') {
+      url.searchParams.set(key, value);
+    }
+  }
+
+  return url.toString();
+}
+
+export function parseScopeList(scope: string | undefined): string[] {
+  if (!scope?.trim()) {
+    return ['openid', 'profile', 'email'];
+  }
+
+  return scope
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}

--- a/examples/brain-oauth/shared/config/apiRoutes.ts
+++ b/examples/brain-oauth/shared/config/apiRoutes.ts
@@ -33,6 +33,15 @@ export const API_CALLBACK = '/api/callback' as const;
 export const API_LOCALES_JSON = '/api/locales/json' as const;
 
 /**
+ * API path: `/api/oauth/consent`
+ *
+ * @see [src/app/api/oauth/consent/route.ts](../../src/app/api/oauth/consent/route.ts)
+ *
+ * **Fallback:** Ctrl/Cmd+P (Quick Open) → `src/app/api/oauth/consent/route.ts`
+ */
+export const API_OAUTH_CONSENT = '/api/oauth/consent' as const;
+
+/**
  * API path: `/api/reference`
  *
  * @see [src/app/api/reference/route.ts](../../src/app/api/reference/route.ts)
@@ -90,6 +99,7 @@ export type ApiRoutePath =
   | typeof API_BRAIN_VERIFY
   | typeof API_CALLBACK
   | typeof API_LOCALES_JSON
+  | typeof API_OAUTH_CONSENT
   | typeof API_REFERENCE
   | typeof API_USER_LOGIN
   | typeof API_USER_LOGOUT

--- a/examples/brain-oauth/shared/config/i18n-identifier/pages/page.oauth-authorize.ts
+++ b/examples/brain-oauth/shared/config/i18n-identifier/pages/page.oauth-authorize.ts
@@ -1,0 +1,191 @@
+/**
+ * @description OAuth authorize page title (header brand + meta)
+ * @localZh Brain OAuth
+ * @localEn Brain OAuth
+ */
+export const PAGE_OAUTH_AUTHORIZE_TITLE = 'page_oauth_authorize:title';
+
+/**
+ * @description OAuth authorize page meta description
+ * @localZh OAuth 授权确认页面
+ * @localEn OAuth authorization consent page
+ */
+export const PAGE_OAUTH_AUTHORIZE_DESCRIPTION =
+  'page_oauth_authorize:description';
+
+/**
+ * @description OAuth authorize page content
+ * @localZh OAuth 授权确认
+ * @localEn OAuth authorization consent
+ */
+export const PAGE_OAUTH_AUTHORIZE_CONTENT = 'page_oauth_authorize:content';
+
+/**
+ * @description OAuth authorize page keywords
+ * @localZh OAuth, 授权, Brain OAuth
+ * @localEn OAuth, authorization, Brain OAuth
+ */
+export const PAGE_OAUTH_AUTHORIZE_KEYWORDS = 'page_oauth_authorize:keywords';
+
+/**
+ * @description Card heading
+ * @localZh 授权请求
+ * @localEn Authorization Request
+ */
+export const PAGE_OAUTH_AUTHORIZE_HEADING = 'page_oauth_authorize:heading';
+
+/**
+ * @description Card subtitle
+ * @localZh 正在请求访问您的账户
+ * @localEn is requesting access to your account
+ */
+export const PAGE_OAUTH_AUTHORIZE_SUBTITLE = 'page_oauth_authorize:subtitle';
+
+/**
+ * @description Application name label
+ * @localZh 应用名称
+ * @localEn Application
+ */
+export const PAGE_OAUTH_AUTHORIZE_APP_LABEL = 'page_oauth_authorize:app__label';
+
+/**
+ * @description Permissions section label
+ * @localZh 请求的权限
+ * @localEn Requested permissions
+ */
+export const PAGE_OAUTH_AUTHORIZE_PERMISSIONS_LABEL =
+  'page_oauth_authorize:permissions__label';
+
+/**
+ * @description openid scope description
+ * @localZh 使用您的身份信息登录
+ * @localEn Authenticate using your identity
+ */
+export const PAGE_OAUTH_AUTHORIZE_PERM_OPENID =
+  'page_oauth_authorize:perm__openid';
+
+/**
+ * @description email scope description
+ * @localZh 查看您的电子邮件地址
+ * @localEn View your email address
+ */
+export const PAGE_OAUTH_AUTHORIZE_PERM_EMAIL =
+  'page_oauth_authorize:perm__email';
+
+/**
+ * @description profile scope description
+ * @localZh 查看您的公开个人资料（姓名、头像）
+ * @localEn View your public profile (name, avatar)
+ */
+export const PAGE_OAUTH_AUTHORIZE_PERM_PROFILE =
+  'page_oauth_authorize:perm__profile';
+
+/**
+ * @description Extra permissions note
+ * @localZh 该应用不会获取您的密码，仅访问您已同意的信息。
+ * @localEn This app will never see your password.
+ */
+export const PAGE_OAUTH_AUTHORIZE_EXTRA_PERM_NOTE =
+  'page_oauth_authorize:extra__perm__note';
+
+/**
+ * @description Trust app checkbox label
+ * @localZh 信任此应用，以后不再询问
+ * @localEn Trust this app and do not ask again
+ */
+export const PAGE_OAUTH_AUTHORIZE_TRUST_OPTION =
+  'page_oauth_authorize:trust__option';
+
+/**
+ * @description Trust option tooltip
+ * @localZh 您将直接授权该应用，无需再次确认。可在开发者控制台撤销。
+ * @localEn You will authorize this app without further prompts. Revoke anytime in settings.
+ */
+export const PAGE_OAUTH_AUTHORIZE_TRUST_TOOLTIP =
+  'page_oauth_authorize:trust__tooltip';
+
+/**
+ * @description Safety note
+ * @localZh 仅授权您信任的应用。您可以随时在账号设置中撤销授权。
+ * @localEn Only authorize apps you trust. You can revoke access anytime.
+ */
+export const PAGE_OAUTH_AUTHORIZE_SAFETY_NOTE =
+  'page_oauth_authorize:safety__note';
+
+/**
+ * @description Deny button
+ * @localZh 拒绝
+ * @localEn Deny
+ */
+export const PAGE_OAUTH_AUTHORIZE_DENY = 'page_oauth_authorize:deny';
+
+/**
+ * @description Allow button
+ * @localZh 同意授权
+ * @localEn Allow
+ */
+export const PAGE_OAUTH_AUTHORIZE_ALLOW = 'page_oauth_authorize:allow';
+
+/**
+ * @description OAuth 2.0 badge
+ * @localZh OAuth 2.0
+ * @localEn OAuth 2.0
+ */
+export const PAGE_OAUTH_AUTHORIZE_OAUTH_BADGE =
+  'page_oauth_authorize:oauth__badge';
+
+/**
+ * @description Deny confirmation message
+ * @localZh 拒绝授权将导致第三方应用无法访问您的信息。确定拒绝？
+ * @localEn Denying will prevent the app from accessing your information. Continue?
+ */
+export const PAGE_OAUTH_AUTHORIZE_DENY_CONFIRM =
+  'page_oauth_authorize:deny__confirm';
+
+/**
+ * @description Footer tagline
+ * @localZh 安全身份验证服务
+ * @localEn Secure identity service
+ */
+export const PAGE_OAUTH_AUTHORIZE_FOOTER_TAGLINE =
+  'page_oauth_authorize:footer__tagline';
+
+/**
+ * @description Generic invalid request error
+ * @localZh 授权请求无效，请检查参数后重试。
+ * @localEn The authorization request is invalid. Check the parameters and try again.
+ */
+export const PAGE_OAUTH_AUTHORIZE_ERROR_INVALID =
+  'page_oauth_authorize:error__invalid';
+
+/**
+ * @description Unknown client error
+ * @localZh 未找到该应用，client_id 无效。
+ * @localEn Application not found. Invalid client_id.
+ */
+export const PAGE_OAUTH_AUTHORIZE_ERROR_CLIENT =
+  'page_oauth_authorize:error__client';
+
+/**
+ * @description Redirect URI mismatch error
+ * @localZh 回调地址未在该应用中注册。
+ * @localEn redirect_uri is not registered for this application.
+ */
+export const PAGE_OAUTH_AUTHORIZE_ERROR_REDIRECT =
+  'page_oauth_authorize:error__redirect';
+
+/**
+ * @description Invalid scope error
+ * @localZh 请求的权限超出该应用允许的范围。
+ * @localEn Requested scope is not allowed for this application.
+ */
+export const PAGE_OAUTH_AUTHORIZE_ERROR_SCOPE =
+  'page_oauth_authorize:error__scope';
+
+/**
+ * @description Consent submission failed
+ * @localZh 授权处理失败，请稍后重试。
+ * @localEn Authorization failed. Please try again later.
+ */
+export const PAGE_OAUTH_AUTHORIZE_ERROR_CONSENT =
+  'page_oauth_authorize:error__consent';

--- a/examples/brain-oauth/shared/config/i18n-mapping/OAuthAuthorizeI18n.ts
+++ b/examples/brain-oauth/shared/config/i18n-mapping/OAuthAuthorizeI18n.ts
@@ -1,0 +1,76 @@
+import { COMMON_ADMIN_TITLE } from '../i18n-identifier/common/common';
+import * as i18nKeys from '../i18n-identifier/pages/page.oauth-authorize';
+
+/**
+ * OAuth authorize page i18n interface
+ */
+export type OAuthAuthorizeI18nInterface = typeof oauthAuthorizeI18n;
+
+export const oauthAuthorizeI18nNamespace = 'page_oauth_authorize';
+
+export const oauthAuthorizeI18n = Object.freeze({
+  title: i18nKeys.PAGE_OAUTH_AUTHORIZE_TITLE,
+  description: i18nKeys.PAGE_OAUTH_AUTHORIZE_DESCRIPTION,
+  content: i18nKeys.PAGE_OAUTH_AUTHORIZE_CONTENT,
+  keywords: i18nKeys.PAGE_OAUTH_AUTHORIZE_KEYWORDS,
+
+  heading: i18nKeys.PAGE_OAUTH_AUTHORIZE_HEADING,
+  subtitle: i18nKeys.PAGE_OAUTH_AUTHORIZE_SUBTITLE,
+  appLabel: i18nKeys.PAGE_OAUTH_AUTHORIZE_APP_LABEL,
+  permissionsLabel: i18nKeys.PAGE_OAUTH_AUTHORIZE_PERMISSIONS_LABEL,
+  permOpenid: i18nKeys.PAGE_OAUTH_AUTHORIZE_PERM_OPENID,
+  permEmail: i18nKeys.PAGE_OAUTH_AUTHORIZE_PERM_EMAIL,
+  permProfile: i18nKeys.PAGE_OAUTH_AUTHORIZE_PERM_PROFILE,
+  extraPermNote: i18nKeys.PAGE_OAUTH_AUTHORIZE_EXTRA_PERM_NOTE,
+  trustOption: i18nKeys.PAGE_OAUTH_AUTHORIZE_TRUST_OPTION,
+  trustTooltip: i18nKeys.PAGE_OAUTH_AUTHORIZE_TRUST_TOOLTIP,
+  safetyNote: i18nKeys.PAGE_OAUTH_AUTHORIZE_SAFETY_NOTE,
+  deny: i18nKeys.PAGE_OAUTH_AUTHORIZE_DENY,
+  allow: i18nKeys.PAGE_OAUTH_AUTHORIZE_ALLOW,
+  oauthBadge: i18nKeys.PAGE_OAUTH_AUTHORIZE_OAUTH_BADGE,
+  denyConfirm: i18nKeys.PAGE_OAUTH_AUTHORIZE_DENY_CONFIRM,
+  footerTagline: i18nKeys.PAGE_OAUTH_AUTHORIZE_FOOTER_TAGLINE,
+  errorInvalid: i18nKeys.PAGE_OAUTH_AUTHORIZE_ERROR_INVALID,
+  errorClient: i18nKeys.PAGE_OAUTH_AUTHORIZE_ERROR_CLIENT,
+  errorRedirect: i18nKeys.PAGE_OAUTH_AUTHORIZE_ERROR_REDIRECT,
+  errorScope: i18nKeys.PAGE_OAUTH_AUTHORIZE_ERROR_SCOPE,
+  errorConsent: i18nKeys.PAGE_OAUTH_AUTHORIZE_ERROR_CONSENT,
+
+  adminTitle: COMMON_ADMIN_TITLE
+});
+
+export function resolveAuthorizeErrorMessage(
+  tt: OAuthAuthorizeI18nInterface,
+  errorKey: string,
+  fallback: string
+): string {
+  switch (errorKey) {
+    case 'unauthorized_client':
+      return fallback.includes('redirect_uri')
+        ? tt.errorRedirect
+        : tt.errorClient;
+    case 'invalid_scope':
+      return tt.errorScope;
+    case 'invalid_request':
+    case 'unsupported_response_type':
+      return tt.errorInvalid;
+    default:
+      return fallback || tt.errorInvalid;
+  }
+}
+
+export function resolveScopeLabel(
+  tt: OAuthAuthorizeI18nInterface,
+  scope: string
+): string {
+  switch (scope) {
+    case 'openid':
+      return tt.permOpenid;
+    case 'email':
+      return tt.permEmail;
+    case 'profile':
+      return tt.permProfile;
+    default:
+      return scope;
+  }
+}

--- a/examples/brain-oauth/shared/config/route.ts
+++ b/examples/brain-oauth/shared/config/route.ts
@@ -20,6 +20,9 @@ export const ROUTE_HOME = '/' as const;
 /** Developer console app list (PRD default post-login redirect). */
 export const ROUTE_DASHBOARD_APPS = '/dashboard/apps' as const;
 
+/** OAuth 2.0 authorization consent page. */
+export const ROUTE_OAUTH_AUTHORIZE = '/oauth/authorize' as const;
+
 /** Routes that are allowed without authentication (public routes). */
 export const AUTH_ROUTES = [ROUTE_HOME, ROUTE_LOGIN, ROUTE_REGISTER] as const;
 

--- a/examples/brain-oauth/shared/schemas/oauth/OAuthAuthorizeSchema.ts
+++ b/examples/brain-oauth/shared/schemas/oauth/OAuthAuthorizeSchema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+export const OAuthClientRowSchema = z.object({
+  id: z.number(),
+  client_id: z.string(),
+  client_name: z.string(),
+  client_uri: z.string().nullable().optional(),
+  logo_uri: z.string().nullable().optional(),
+  redirect_uris: z.array(z.string()),
+  grant_types: z.array(z.string()),
+  scopes: z.array(z.string()),
+  confidential: z.boolean(),
+  owner_user_id: z.number(),
+  created_at: z.string(),
+  updated_at: z.string()
+});
+
+export type OAuthClientRow = z.infer<typeof OAuthClientRowSchema>;
+
+export const OAuthAuthorizeQuerySchema = z.object({
+  response_type: z.literal('code'),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().url(),
+  scope: z.string().optional(),
+  state: z.string().optional()
+});
+
+export type OAuthAuthorizeQuery = z.infer<typeof OAuthAuthorizeQuerySchema>;
+
+export const OAuthConsentBodySchema = z.object({
+  action: z.enum(['allow', 'deny']),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().url(),
+  scope: z.string().optional(),
+  state: z.string().optional(),
+  trust: z.boolean().optional()
+});
+
+export type OAuthConsentBody = z.infer<typeof OAuthConsentBodySchema>;
+
+export const OAuthAuthorizationCodeRowSchema = z.object({
+  code: z.string(),
+  client_id: z.string(),
+  user_id: z.number(),
+  redirect_uri: z.string(),
+  scope: z.string().nullable().optional(),
+  expires_at: z.string(),
+  used: z.boolean(),
+  created_at: z.string()
+});
+
+export type OAuthAuthorizationCodeRow = z.infer<
+  typeof OAuthAuthorizationCodeRowSchema
+>;

--- a/examples/brain-oauth/shared/supabase/proxy.ts
+++ b/examples/brain-oauth/shared/supabase/proxy.ts
@@ -12,7 +12,9 @@ export async function updateSession(request: NextRequest) {
 
   if (!session && !isPublicPath(pathname)) {
     const url = request.nextUrl.clone();
+    const returnPath = `${pathname}${request.nextUrl.search}`;
     url.pathname = ROUTE_LOGIN;
+    url.search = `redirect=${encodeURIComponent(returnPath)}`;
     return NextResponse.redirect(url);
   }
 

--- a/examples/brain-oauth/shared/validators/OAuthAuthorizeValidator.ts
+++ b/examples/brain-oauth/shared/validators/OAuthAuthorizeValidator.ts
@@ -1,0 +1,58 @@
+import { injectable } from '@shared/container';
+import {
+  OAuthAuthorizeQuerySchema,
+  OAuthConsentBodySchema,
+  type OAuthAuthorizeQuery,
+  type OAuthConsentBody
+} from '@schemas/oauth/OAuthAuthorizeSchema';
+import type {
+  ValidationResult,
+  ValidatorInterface
+} from './ValidatorInterface';
+
+/**
+ * Validates OAuth authorize query params and consent POST body.
+ */
+@injectable()
+export class OAuthAuthorizeQueryValidator
+  implements ValidatorInterface<OAuthAuthorizeQuery>
+{
+  public validate(data: unknown): ValidationResult<OAuthAuthorizeQuery> {
+    const result = OAuthAuthorizeQuerySchema.safeParse(data);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      return {
+        success: false,
+        path: issue?.path ?? [],
+        message: issue?.message ?? 'Invalid query'
+      };
+    }
+    return { success: true, data: result.data };
+  }
+
+  public getThrow(input: unknown): OAuthAuthorizeQuery {
+    return OAuthAuthorizeQuerySchema.parse(input);
+  }
+}
+
+@injectable()
+export class OAuthConsentBodyValidator
+  implements ValidatorInterface<OAuthConsentBody>
+{
+  public validate(data: unknown): ValidationResult<OAuthConsentBody> {
+    const result = OAuthConsentBodySchema.safeParse(data);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      return {
+        success: false,
+        path: issue?.path ?? [],
+        message: issue?.message ?? 'Invalid body'
+      };
+    }
+    return { success: true, data: result.data };
+  }
+
+  public getThrow(input: unknown): OAuthConsentBody {
+    return OAuthConsentBodySchema.parse(input);
+  }
+}

--- a/examples/brain-oauth/src/app/[locale]/oauth/authorize/page.tsx
+++ b/examples/brain-oauth/src/app/[locale]/oauth/authorize/page.tsx
@@ -1,0 +1,89 @@
+import { Suspense } from 'react';
+import { AppRoutePage } from '@/uikit/components-app/AppRoutePage';
+import { OAuthAuthorizeCard } from '@/uikit/components-app/oauth/OAuthAuthorizeCard';
+import { OAuthAuthorizeErrorCard } from '@/uikit/components-app/oauth/OAuthAuthorizeErrorCard';
+import { PageI18nProvider } from '@/uikit/context/PageI18nContext';
+import { i18nConfig } from '@config/i18n';
+import {
+  oauthAuthorizeI18n,
+  oauthAuthorizeI18nNamespace,
+  resolveAuthorizeErrorMessage
+} from '@config/i18n-mapping/OAuthAuthorizeI18n';
+import type { PageParamsProps } from '@interfaces/AppPageRouter';
+import { BootstrapServer } from '@server/BootstrapServer';
+import {
+  AppPageRouteParams,
+  type PageParamsType
+} from '@server/render/AppPageRouteParams';
+import { OAuthAuthorizeService } from '@server/services/OAuthAuthorizeService';
+import type { Metadata } from 'next';
+
+export async function generateStaticParams() {
+  return i18nConfig.supportedLngs.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<PageParamsType>;
+}): Promise<Metadata> {
+  const pageParams = new AppPageRouteParams(await params);
+  return await pageParams.getI18nInterface(oauthAuthorizeI18n);
+}
+
+type OAuthAuthorizePageProps = PageParamsProps & {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function OAuthAuthorizePage(props: OAuthAuthorizePageProps) {
+  const params = await props.params!;
+  const pageParams = new AppPageRouteParams(params);
+  const tt = await pageParams.getI18nInterface(
+    oauthAuthorizeI18n,
+    oauthAuthorizeI18nNamespace
+  );
+
+  const rawSearchParams = (await props.searchParams) ?? {};
+  const IOC = new BootstrapServer('OAuthAuthorizePage').getIOC();
+  const authorizeResult = await IOC(OAuthAuthorizeService).resolveAuthorizePage(
+    rawSearchParams
+  );
+
+  return (
+    <PageI18nProvider value={tt}>
+      <AppRoutePage
+        data-testid="AppRoute-OAuthAuthorizePage"
+        tt={{ title: tt.title, adminTitle: tt.adminTitle }}
+        showAuthButton={false}
+      >
+        <div className="flex flex-1 flex-col">
+          <div className="flex flex-1 items-center justify-center px-4 py-12">
+            {authorizeResult.ok ? (
+              <Suspense>
+                <OAuthAuthorizeCard
+                  tt={tt}
+                  authorizeData={authorizeResult.data}
+                />
+              </Suspense>
+            ) : (
+              <OAuthAuthorizeErrorCard
+                tt={tt}
+                message={resolveAuthorizeErrorMessage(
+                  tt,
+                  authorizeResult.error.errorKey,
+                  authorizeResult.error.message
+                )}
+              />
+            )}
+          </div>
+
+          <footer className="text-center text-sm text-secondary-text py-6 border-t border-primary-border">
+            <p>
+              © 2026 {tt.title} · {tt.footerTagline}
+            </p>
+          </footer>
+        </div>
+      </AppRoutePage>
+    </PageI18nProvider>
+  );
+}

--- a/examples/brain-oauth/src/app/api/oauth/consent/route.ts
+++ b/examples/brain-oauth/src/app/api/oauth/consent/route.ts
@@ -1,0 +1,33 @@
+import { OAuthConsentController } from '@server/controllers/OAuthConsentController';
+import { NextApiServer } from '@server/NextApiServer';
+import { NextResponse, type NextRequest } from 'next/server';
+
+/**
+ * OAuth consent submission: allow or deny authorization for a registered client.
+ */
+export async function POST(req: NextRequest) {
+  let requestBody: unknown;
+  try {
+    requestBody = await req.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, id: 'invalid_request', message: 'Invalid JSON' },
+      { status: 400 }
+    );
+  }
+
+  const server = new NextApiServer('/api/oauth/consent', req);
+  const result = await server.run(async ({ parameters: { IOC } }) =>
+    IOC(OAuthConsentController).submitConsent(requestBody)
+  );
+
+  if (!result.success) {
+    const status = result.id === 'access_denied' ? 401 : 400;
+    return NextResponse.json(result, { status });
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: result.data
+  });
+}

--- a/examples/brain-oauth/src/i18n/routing.ts
+++ b/examples/brain-oauth/src/i18n/routing.ts
@@ -2,7 +2,13 @@ import { createNavigation } from 'next-intl/navigation';
 import { defineRouting } from 'next-intl/routing';
 import { useLocaleRoutes } from '@config/common';
 import { i18nConfig } from '@config/i18n';
-import { ROUTE_LOGIN, ROUTE_REGISTER, ROUTE_REQUEST_LOGS, ROUTE_DASHBOARD_APPS } from '@config/route';
+import {
+  ROUTE_DASHBOARD_APPS,
+  ROUTE_LOGIN,
+  ROUTE_OAUTH_AUTHORIZE,
+  ROUTE_REGISTER,
+  ROUTE_REQUEST_LOGS
+} from '@config/route';
 
 const locales = i18nConfig.supportedLngs;
 
@@ -35,6 +41,10 @@ export const routing = defineRouting({
     [ROUTE_DASHBOARD_APPS]: {
       en: '/dashboard/apps',
       zh: '/dashboard/apps'
+    },
+    [ROUTE_OAUTH_AUTHORIZE]: {
+      en: '/oauth/authorize',
+      zh: '/oauth/authorize'
     },
     '/about': {
       en: '/about',

--- a/examples/brain-oauth/src/impls/ClientIOCRegister.ts
+++ b/examples/brain-oauth/src/impls/ClientIOCRegister.ts
@@ -3,6 +3,7 @@ import { Base64Serializer, StorageExecutor } from '@qlover/fe-corekit';
 import { I18nService } from '@/impls/I18nService';
 import { RouterService } from '@/impls/RouterService';
 import { BrainAuthGateway } from '@/impls/BrainAuthGateway';
+import { OAuthConsentGateway } from '@/impls/OAuthConsentGateway';
 import { UserService } from '@/impls/UserService';
 import { ZustandCounterService } from '@/impls/ZustandCounterService';
 import { StringEncryptor } from '@shared/StringEncryptor';
@@ -39,6 +40,7 @@ export const ClientIOCRegister: IOCRegisterInterface<IOCContainerInterface> = {
     ioc.bind(I.RouterServiceInterface, ioc.get(RouterService));
     ioc.bind(I.UserServiceInterface, ioc.get(UserService));
     ioc.bind(BrainAuthGateway, ioc.get(BrainAuthGateway));
+    ioc.bind(OAuthConsentGateway, ioc.get(OAuthConsentGateway));
     ioc.bind(I.ZustandCounterServiceInterface, new ZustandCounterService());
 
     new AppApiRegister(JSON).register(ioc);

--- a/examples/brain-oauth/src/impls/OAuthConsentGateway.ts
+++ b/examples/brain-oauth/src/impls/OAuthConsentGateway.ts
@@ -1,0 +1,52 @@
+import { HttpMethods } from '@qlover/fe-corekit';
+import { inject, injectable } from '@shared/container';
+import {
+  AppApiRequester,
+  type AppApiConfig,
+  type AppApiRequesterContext
+} from './appApi/AppApiRequester';
+import type { RequestExecutor } from '@qlover/fe-corekit';
+
+export type OAuthConsentPayload = {
+  action: 'allow' | 'deny';
+  client_id: string;
+  redirect_uri: string;
+  scope?: string;
+  state?: string;
+  trust?: boolean;
+};
+
+export type OAuthConsentResponse = {
+  success: boolean;
+  data?: { redirectUrl: string };
+  id?: string;
+  message?: string;
+};
+
+/**
+ * Client gateway for OAuth consent submission (`POST /api/oauth/consent`).
+ */
+@injectable()
+export class OAuthConsentGateway {
+  constructor(
+    @inject(AppApiRequester)
+    protected client: RequestExecutor<AppApiConfig, AppApiRequesterContext>
+  ) {}
+
+  public async submit(payload: OAuthConsentPayload): Promise<string> {
+    const response = await this.client.request<
+      OAuthConsentResponse,
+      OAuthConsentPayload
+    >({
+      url: '/api/oauth/consent',
+      method: HttpMethods.POST,
+      data: payload
+    });
+
+    if (!response.data.success || !response.data.data?.redirectUrl) {
+      throw new Error(response.data.message ?? 'Consent submission failed');
+    }
+
+    return response.data.data.redirectUrl;
+  }
+}

--- a/examples/brain-oauth/src/uikit/components-app/oauth/OAuthAuthorizeCard.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/oauth/OAuthAuthorizeCard.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import {
+  AppstoreOutlined,
+  CheckCircleOutlined,
+  DownOutlined,
+  ExclamationCircleOutlined,
+  InfoCircleOutlined,
+  LoadingOutlined,
+  LockOutlined,
+  QuestionCircleOutlined
+} from '@ant-design/icons';
+import { clsx } from 'clsx';
+import { useCallback, useMemo, useState } from 'react';
+import { useIOC } from '@/uikit/hook/useIOC';
+import { OAuthConsentGateway } from '@/impls/OAuthConsentGateway';
+import type { OAuthAuthorizeI18nInterface } from '@config/i18n-mapping/OAuthAuthorizeI18n';
+import { resolveScopeLabel } from '@config/i18n-mapping/OAuthAuthorizeI18n';
+import type { OAuthAuthorizePageData } from '@server/services/OAuthAuthorizeService';
+
+export interface OAuthAuthorizeCardProps {
+  tt: OAuthAuthorizeI18nInterface;
+  authorizeData: OAuthAuthorizePageData;
+}
+
+export function OAuthAuthorizeCard({
+  tt,
+  authorizeData
+}: OAuthAuthorizeCardProps) {
+  const consentGateway = useIOC(OAuthConsentGateway);
+  const [extraOpen, setExtraOpen] = useState(false);
+  const [trust, setTrust] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const scopeLabels = useMemo(
+    () =>
+      authorizeData.scopes.map((scope) => ({
+        scope,
+        label: resolveScopeLabel(tt, scope)
+      })),
+    [authorizeData.scopes, tt]
+  );
+
+  const scopeParam = authorizeData.scopes.join(' ');
+
+  const submitConsent = useCallback(
+    async (action: 'allow' | 'deny') => {
+      setLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const redirectUrl = await consentGateway.submit({
+          action,
+          client_id: authorizeData.clientId,
+          redirect_uri: authorizeData.redirectUri,
+          scope: scopeParam || undefined,
+          state: authorizeData.state,
+          trust: action === 'allow' ? trust : undefined
+        });
+
+        window.location.assign(redirectUrl);
+      } catch (err) {
+        setErrorMessage(
+          err instanceof Error ? err.message : tt.errorConsent
+        );
+        setLoading(false);
+      }
+    },
+    [authorizeData, consentGateway, scopeParam, trust, tt.errorConsent]
+  );
+
+  const handleAllow = () => {
+    void submitConsent('allow');
+  };
+
+  const handleDeny = () => {
+    if (!window.confirm(tt.denyConfirm)) {
+      return;
+    }
+    void submitConsent('deny');
+  };
+
+  return (
+    <div
+      data-testid="OAuthAuthorizeCard"
+      className="max-w-lg w-full bg-primary rounded-2xl shadow-xl border border-primary-border overflow-hidden"
+    >
+      {errorMessage && (
+        <div
+          role="alert"
+          className="mx-6 mt-4 bg-red-50 dark:bg-red-900/30 border-l-4 border-red-500 p-3 rounded text-sm text-red-700 dark:text-red-300"
+        >
+          <ExclamationCircleOutlined className="mr-2" />
+          {errorMessage}
+        </div>
+      )}
+
+      <div className="p-6 border-b border-primary-border">
+        <div className="flex items-center gap-3">
+          <div className="w-12 h-12 rounded-full bg-brand/10 flex items-center justify-center text-brand text-xl overflow-hidden shrink-0">
+            {authorizeData.logoUri ? (
+              // eslint-disable-next-line @next/next/no-img-element -- third-party app logos use arbitrary URLs
+              <img
+                src={authorizeData.logoUri}
+                alt=""
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <AppstoreOutlined />
+            )}
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold text-primary-text">
+              {tt.heading}
+            </h2>
+            <p className="text-sm text-secondary-text">{tt.subtitle}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 space-y-5">
+        <div className="bg-elevated rounded-lg p-4">
+          <div className="flex justify-between items-start gap-3">
+            <div className="min-w-0">
+              <p className="text-xs text-secondary-text uppercase tracking-wide">
+                {tt.appLabel}
+              </p>
+              <p className="font-semibold text-lg text-primary-text truncate">
+                {authorizeData.clientName}
+              </p>
+              {authorizeData.clientUri && (
+                <p className="text-sm text-secondary-text truncate">
+                  {authorizeData.clientUri}
+                </p>
+              )}
+            </div>
+            <span className="bg-brand/10 text-brand text-xs px-2 py-1 rounded-full shrink-0">
+              {tt.oauthBadge}
+            </span>
+          </div>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            className="flex w-full justify-between items-center cursor-pointer text-left"
+            onClick={() => setExtraOpen((open) => !open)}
+            aria-expanded={extraOpen}
+          >
+            <p className="text-sm font-medium flex items-center gap-1 text-primary-text">
+              <LockOutlined />
+              {tt.permissionsLabel}
+            </p>
+            <DownOutlined
+              className={clsx(
+                'text-secondary-text transition-transform text-xs',
+                extraOpen && 'rotate-180'
+              )}
+            />
+          </button>
+          <div className="mt-2 space-y-2 pl-1">
+            {scopeLabels.map(({ scope, label }) => (
+              <div key={scope} className="flex items-start gap-2">
+                <CheckCircleOutlined className="text-green-500 text-sm mt-0.5 shrink-0" />
+                <span className="text-sm text-primary-text">{label}</span>
+              </div>
+            ))}
+          </div>
+          <div
+            className={clsx(
+              'mt-2 pl-5 text-xs text-secondary-text border-l-2 border-brand/40',
+              !extraOpen && 'hidden'
+            )}
+          >
+            <p>{tt.extraPermNote}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between pt-2 gap-2">
+          <div className="flex items-center min-w-0">
+            <input
+              type="checkbox"
+              id="trustCheckbox"
+              checked={trust}
+              onChange={(e) => setTrust(e.target.checked)}
+              className="w-4 h-4 text-brand rounded focus:ring-brand shrink-0"
+            />
+            <label
+              htmlFor="trustCheckbox"
+              className="ml-2 text-sm text-primary-text"
+            >
+              {tt.trustOption}
+            </label>
+          </div>
+          <QuestionCircleOutlined
+            className="text-secondary-text text-xs shrink-0"
+            title={tt.trustTooltip}
+          />
+        </div>
+
+        <div className="bg-amber-50 dark:bg-amber-950/30 border-l-4 border-amber-500 p-3 rounded text-sm text-primary-text">
+          <InfoCircleOutlined className="text-amber-600 mr-2" />
+          {tt.safetyNote}
+        </div>
+      </div>
+
+      <div className="p-6 border-t border-primary-border bg-elevated flex flex-col sm:flex-row gap-3">
+        <button
+          type="button"
+          id="denyBtn"
+          disabled={loading}
+          onClick={handleDeny}
+          className="flex-1 px-4 py-2 rounded-lg border border-primary-border hover:bg-secondary transition font-medium text-primary-text disabled:opacity-60"
+        >
+          {tt.deny}
+        </button>
+        <button
+          type="button"
+          id="allowBtn"
+          disabled={loading}
+          onClick={handleAllow}
+          className="flex-1 px-4 py-2 rounded-lg bg-brand text-on-brand hover:bg-brand-hover transition font-medium shadow-sm flex items-center justify-center gap-2 disabled:opacity-60"
+        >
+          {tt.allow}
+          {loading && <LoadingOutlined spin />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/examples/brain-oauth/src/uikit/components-app/oauth/OAuthAuthorizeErrorCard.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/oauth/OAuthAuthorizeErrorCard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ExclamationCircleOutlined } from '@ant-design/icons';
+import type { OAuthAuthorizeI18nInterface } from '@config/i18n-mapping/OAuthAuthorizeI18n';
+
+export interface OAuthAuthorizeErrorCardProps {
+  tt: OAuthAuthorizeI18nInterface;
+  message: string;
+}
+
+export function OAuthAuthorizeErrorCard({
+  tt,
+  message
+}: OAuthAuthorizeErrorCardProps) {
+  return (
+    <div
+      data-testid="OAuthAuthorizeErrorCard"
+      className="max-w-lg w-full bg-primary rounded-2xl shadow-xl border border-primary-border overflow-hidden p-6"
+    >
+      <div className="flex items-start gap-3">
+        <ExclamationCircleOutlined className="text-red-500 text-xl mt-0.5 shrink-0" />
+        <div>
+          <h2 className="text-xl font-semibold text-primary-text mb-2">
+            {tt.heading}
+          </h2>
+          <p className="text-sm text-secondary-text">{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Added OAuth authorization page prototype in HTML, featuring a responsive design and localization support for Chinese and English.
- Implemented OAuthConsentController and OAuthConsentService to handle user consent submissions.
- Created repositories for managing OAuth authorization codes and clients, ensuring secure storage and retrieval.
- Developed utility functions for building OAuth redirect URLs and parsing scope lists.
- Integrated validation for OAuth query parameters and consent body using Zod schemas.
- Enhanced routing and i18n mapping to support the new OAuth consent flow.

This commit establishes a foundational structure for the OAuth 2.0 authorization process, improving user experience and security in the Brain OAuth application.