### PR TITLE
feat(brain-oauth): Implement OAuth token exchange functionality

### DIFF
--- a/examples/brain-oauth/server/controllers/OAuthTokenController.ts
+++ b/examples/brain-oauth/server/controllers/OAuthTokenController.ts
@@ -1,0 +1,19 @@
+import { inject, injectable } from '@shared/container';
+import { OAuthTokenService } from '../services/OAuthTokenService';
+import type { OAuthTokenResponse } from '@schemas/oauth/OAuthClientSchema';
+
+/**
+ * HTTP entry for OAuth token exchange (`POST /oauth/token`).
+ */
+@injectable()
+export class OAuthTokenController {
+  constructor(
+    @inject(OAuthTokenService) protected tokenService: OAuthTokenService
+  ) {}
+
+  public async exchangeToken(
+    fields: Record<string, string>
+  ): Promise<OAuthTokenResponse> {
+    return await this.tokenService.exchangeToken(fields);
+  }
+}

--- a/examples/brain-oauth/server/repositorys/OAuthAuthorizationCodesRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthAuthorizationCodesRepository.ts
@@ -1,5 +1,6 @@
 import { injectable } from '@shared/container';
 import { createAdminClient } from '@shared/supabase/admin';
+import type { OAuthAuthorizationCodeRow } from '@schemas/oauth/OAuthAuthorizeSchema';
 
 export type CreateAuthorizationCodeInput = {
   code: string;
@@ -30,5 +31,28 @@ export class OAuthAuthorizationCodesRepository {
     if (error) {
       throw new Error(error.message);
     }
+  }
+
+  /**
+   * Atomically marks a valid, unused, non-expired code as used and returns the row.
+   */
+  public async consumeCode(
+    code: string
+  ): Promise<OAuthAuthorizationCodeRow | null> {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from('brain_oauth_authorization_codes')
+      .update({ used: true })
+      .eq('code', code)
+      .eq('used', false)
+      .gt('expires_at', new Date().toISOString())
+      .select('*')
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return (data as OAuthAuthorizationCodeRow | null) ?? null;
   }
 }

--- a/examples/brain-oauth/server/repositorys/OAuthClientsRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthClientsRepository.ts
@@ -1,5 +1,6 @@
 import { injectable } from '@shared/container';
 import { createAdminClient } from '@shared/supabase/admin';
+import { verifyClientSecret } from '@server/utils/clientSecretHash';
 import type { OAuthClientRow } from '@schemas/oauth/OAuthAuthorizeSchema';
 
 /**
@@ -20,5 +21,30 @@ export class OAuthClientsRepository {
     }
 
     return (data as OAuthClientRow | null) ?? null;
+  }
+
+  public async verifyClientCredentials(
+    clientId: string,
+    clientSecret: string | undefined
+  ): Promise<OAuthClientRow> {
+    const client = await this.findByClientId(clientId);
+    if (!client) {
+      throw new Error('invalid_client');
+    }
+
+    if (client.confidential) {
+      if (!clientSecret?.trim()) {
+        throw new Error('invalid_client');
+      }
+      const valid = await verifyClientSecret(
+        clientSecret,
+        client.client_secret_hash
+      );
+      if (!valid) {
+        throw new Error('invalid_client');
+      }
+    }
+
+    return client;
   }
 }

--- a/examples/brain-oauth/server/repositorys/OAuthRefreshTokensRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthRefreshTokensRepository.ts
@@ -1,0 +1,60 @@
+import { injectable } from '@shared/container';
+import { createAdminClient } from '@shared/supabase/admin';
+import type { OAuthRefreshTokenRow } from '@schemas/oauth/OAuthClientSchema';
+
+export type CreateOAuthRefreshTokenInput = {
+  refresh_token: string;
+  client_id: string;
+  user_id: number;
+  expires_at: string;
+};
+
+/**
+ * Middleware-issued refresh tokens mapped to Brain users and OAuth clients.
+ */
+@injectable()
+export class OAuthRefreshTokensRepository {
+  public async findByTokenHash(
+    tokenHash: string
+  ): Promise<OAuthRefreshTokenRow | null> {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase
+      .from('brain_oauth_refresh_tokens')
+      .select('*')
+      .eq('refresh_token', tokenHash)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return (data as OAuthRefreshTokenRow | null) ?? null;
+  }
+
+  public async create(input: CreateOAuthRefreshTokenInput): Promise<void> {
+    const supabase = createAdminClient();
+    const { error } = await supabase.from('brain_oauth_refresh_tokens').insert({
+      refresh_token: input.refresh_token,
+      client_id: input.client_id,
+      user_id: input.user_id,
+      expires_at: input.expires_at,
+      revoked: false
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+
+  public async revokeByTokenHash(tokenHash: string): Promise<void> {
+    const supabase = createAdminClient();
+    const { error } = await supabase
+      .from('brain_oauth_refresh_tokens')
+      .update({ revoked: true })
+      .eq('refresh_token', tokenHash);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+}

--- a/examples/brain-oauth/server/services/OAuthTokenService.ts
+++ b/examples/brain-oauth/server/services/OAuthTokenService.ts
@@ -1,0 +1,213 @@
+import { randomBytes } from 'crypto';
+import { inject, injectable } from '@shared/container';
+import { I } from '@config/ioc-identifiter';
+import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
+import {
+  OAuthTokenRequestSchema,
+  type OAuthTokenRequest
+} from '@schemas/oauth/OAuthTokenSchema';
+import type { OAuthTokenResponse } from '@schemas/oauth/OAuthClientSchema';
+import { BrainUserAdapter } from '../adapters/BrainUserAdapter';
+import { OAuthAuthorizationCodesRepository } from '../repositorys/OAuthAuthorizationCodesRepository';
+import { OAuthClientsRepository } from '../repositorys/OAuthClientsRepository';
+import {
+  OAuthCredentialsRepository,
+  hashOpaqueToken
+} from '../repositorys/OAuthCredentialsRepository';
+import { OAuthRefreshTokensRepository } from '../repositorys/OAuthRefreshTokensRepository';
+import { OAuthTokenError } from '../utils/oauthTokenError';
+import { TokenEncryption } from '../utils/TokenEncryption';
+
+/**
+ * OAuth 2.0 token endpoint (`POST /oauth/token`).
+ *
+ * Significance: Exchanges authorization codes and refresh tokens for Brain access tokens.
+ * Core idea: Validate client + grant, consume codes, proxy Brain token APIs.
+ * Main purpose: Standard token endpoint for third-party OAuth clients.
+ *
+ * @example
+ * const tokens = await service.exchangeToken(formFields);
+ */
+@injectable()
+export class OAuthTokenService {
+  protected static REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+  protected tokenEncryption: TokenEncryption;
+
+  constructor(
+    @inject(OAuthClientsRepository)
+    protected clientsRepo: OAuthClientsRepository,
+    @inject(OAuthAuthorizationCodesRepository)
+    protected authCodesRepo: OAuthAuthorizationCodesRepository,
+    @inject(OAuthRefreshTokensRepository)
+    protected refreshTokensRepo: OAuthRefreshTokensRepository,
+    @inject(OAuthCredentialsRepository)
+    protected credentialsRepo: OAuthCredentialsRepository,
+    @inject(BrainUserAdapter)
+    protected brainAdapter: BrainUserAdapter,
+    @inject(I.AppConfig) config: SeedServerConfigInterface
+  ) {
+    this.tokenEncryption = new TokenEncryption(config.encryptionKey);
+  }
+
+  public async exchangeToken(
+    rawFields: Record<string, string>
+  ): Promise<OAuthTokenResponse> {
+    let request: OAuthTokenRequest;
+    try {
+      request = OAuthTokenRequestSchema.parse(rawFields);
+    } catch {
+      throw new OAuthTokenError(
+        'invalid_request',
+        400,
+        'Malformed token request'
+      );
+    }
+
+    let client;
+    try {
+      client = await this.clientsRepo.verifyClientCredentials(
+        request.client_id,
+        request.client_secret
+      );
+    } catch {
+      throw new OAuthTokenError('invalid_client', 401);
+    }
+
+    if (!client.grant_types.includes(request.grant_type)) {
+      throw new OAuthTokenError('unsupported_grant_type', 400);
+    }
+
+    if (request.grant_type === 'authorization_code') {
+      return await this.exchangeAuthorizationCode(request, client.client_id);
+    }
+
+    return await this.exchangeRefreshToken(request, client.client_id);
+  }
+
+  protected async exchangeAuthorizationCode(
+    request: Extract<OAuthTokenRequest, { grant_type: 'authorization_code' }>,
+    verifiedClientId: string
+  ): Promise<OAuthTokenResponse> {
+    const authCode = await this.authCodesRepo.consumeCode(request.code);
+    if (!authCode) {
+      throw new OAuthTokenError(
+        'invalid_grant',
+        400,
+        'Authorization code is invalid, expired, or already used'
+      );
+    }
+
+    if (authCode.client_id !== verifiedClientId) {
+      throw new OAuthTokenError('invalid_grant', 400, 'client_id mismatch');
+    }
+
+    if (authCode.redirect_uri !== request.redirect_uri) {
+      throw new OAuthTokenError('invalid_grant', 400, 'redirect_uri mismatch');
+    }
+
+    const brainTokens = await this.fetchBrainAccessToken(authCode.user_id);
+    const middlewareRefresh = await this.issueMiddlewareRefreshToken(
+      authCode.client_id,
+      authCode.user_id
+    );
+
+    return {
+      access_token: brainTokens.access_token,
+      token_type: 'Bearer',
+      expires_in: brainTokens.expires_in,
+      refresh_token: middlewareRefresh,
+      scope: authCode.scope ?? undefined
+    };
+  }
+
+  protected async exchangeRefreshToken(
+    request: Extract<OAuthTokenRequest, { grant_type: 'refresh_token' }>,
+    verifiedClientId: string
+  ): Promise<OAuthTokenResponse> {
+    const tokenHash = hashOpaqueToken(request.refresh_token);
+    const stored = await this.refreshTokensRepo.findByTokenHash(tokenHash);
+
+    if (
+      !stored ||
+      stored.revoked ||
+      stored.client_id !== verifiedClientId ||
+      new Date(stored.expires_at) <= new Date()
+    ) {
+      throw new OAuthTokenError('invalid_grant', 400, 'Refresh token is invalid');
+    }
+
+    const brainTokens = await this.fetchBrainAccessToken(stored.user_id);
+
+    await this.refreshTokensRepo.revokeByTokenHash(tokenHash);
+    const middlewareRefresh = await this.issueMiddlewareRefreshToken(
+      stored.client_id,
+      stored.user_id
+    );
+
+    return {
+      access_token: brainTokens.access_token,
+      token_type: 'Bearer',
+      expires_in: brainTokens.expires_in,
+      refresh_token: middlewareRefresh
+    };
+  }
+
+  protected async fetchBrainAccessToken(userId: number): Promise<{
+    access_token: string;
+    expires_in: number;
+  }> {
+    const credentials = await this.credentialsRepo.getUserCredentials(userId);
+    const sessionToken = credentials?.brain_session_token?.trim();
+
+    if (!sessionToken) {
+      throw new OAuthTokenError(
+        'invalid_grant',
+        400,
+        'User credentials expired. Re-authorization required.'
+      );
+    }
+
+    try {
+      const access = await this.brainAdapter.exchangeAccessToken({
+        token: sessionToken
+      });
+
+      if (access.refresh_token) {
+        await this.credentialsRepo.upsertUserCredentials(userId, {
+          brain_refresh_token: this.tokenEncryption.encrypt(access.refresh_token)
+        });
+      }
+
+      return {
+        access_token: access.access_token,
+        expires_in: access.expires_in
+      };
+    } catch {
+      throw new OAuthTokenError(
+        'invalid_grant',
+        400,
+        'Failed to obtain access token from Brain'
+      );
+    }
+  }
+
+  protected async issueMiddlewareRefreshToken(
+    clientId: string,
+    userId: number
+  ): Promise<string> {
+    const plain = randomBytes(32).toString('base64url');
+    const expiresAt = new Date(
+      Date.now() + OAuthTokenService.REFRESH_TOKEN_TTL_MS
+    ).toISOString();
+
+    await this.refreshTokensRepo.create({
+      refresh_token: hashOpaqueToken(plain),
+      client_id: clientId,
+      user_id: userId,
+      expires_at: expiresAt
+    });
+
+    return plain;
+  }
+}

--- a/examples/brain-oauth/server/utils/clientSecretHash.ts
+++ b/examples/brain-oauth/server/utils/clientSecretHash.ts
@@ -1,0 +1,41 @@
+import { randomBytes, scrypt, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
+
+const scryptAsync = promisify(scrypt);
+const PREFIX = 'scrypt';
+const KEY_LEN = 64;
+
+/**
+ * Hashes OAuth client secrets for storage (scrypt, Node built-in).
+ *
+ * @example
+ * const hash = await hashClientSecret('my-secret');
+ */
+export async function hashClientSecret(secret: string): Promise<string> {
+  const salt = randomBytes(16);
+  const derived = (await scryptAsync(secret, salt, KEY_LEN)) as Buffer;
+  return `${PREFIX}$${salt.toString('base64')}$${derived.toString('base64')}`;
+}
+
+/**
+ * Verifies a plaintext client secret against a stored scrypt hash.
+ */
+export async function verifyClientSecret(
+  secret: string,
+  storedHash: string
+): Promise<boolean> {
+  const parts = storedHash.split('$');
+  if (parts.length !== 3 || parts[0] !== PREFIX) {
+    return false;
+  }
+
+  const salt = Buffer.from(parts[1]!, 'base64');
+  const expected = Buffer.from(parts[2]!, 'base64');
+  const derived = (await scryptAsync(secret, salt, expected.length)) as Buffer;
+
+  if (derived.length !== expected.length) {
+    return false;
+  }
+
+  return timingSafeEqual(derived, expected);
+}

--- a/examples/brain-oauth/server/utils/oauthTokenError.ts
+++ b/examples/brain-oauth/server/utils/oauthTokenError.ts
@@ -1,0 +1,25 @@
+/**
+ * OAuth 2.0 token endpoint error (RFC 6749).
+ */
+export class OAuthTokenError extends Error {
+  constructor(
+    public readonly error: string,
+    public readonly status: number,
+    public readonly errorDescription?: string
+  ) {
+    super(errorDescription ?? error);
+    this.name = 'OAuthTokenError';
+  }
+}
+
+export function oauthTokenErrorResponse(err: OAuthTokenError): Response {
+  return Response.json(
+    {
+      error: err.error,
+      ...(err.errorDescription
+        ? { error_description: err.errorDescription }
+        : {})
+    },
+    { status: err.status }
+  );
+}

--- a/examples/brain-oauth/server/utils/parseOAuthTokenRequest.ts
+++ b/examples/brain-oauth/server/utils/parseOAuthTokenRequest.ts
@@ -1,0 +1,69 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * Parses OAuth token POST body (application/x-www-form-urlencoded or multipart).
+ * Merges optional HTTP Basic client credentials.
+ */
+export async function parseOAuthTokenRequest(
+  req: NextRequest
+): Promise<Record<string, string>> {
+  const contentType = req.headers.get('content-type') ?? '';
+  let fields: Record<string, string> = {};
+
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    const text = await req.text();
+    fields = Object.fromEntries(new URLSearchParams(text));
+  } else if (contentType.includes('multipart/form-data')) {
+    const form = await req.formData();
+    for (const [key, value] of form.entries()) {
+      if (typeof value === 'string') {
+        fields[key] = value;
+      }
+    }
+  } else if (contentType.includes('application/json')) {
+    const json = (await req.json()) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(json)) {
+      if (typeof value === 'string') {
+        fields[key] = value;
+      }
+    }
+  } else {
+    const text = await req.text();
+    if (text.trim()) {
+      fields = Object.fromEntries(new URLSearchParams(text));
+    }
+  }
+
+  const basic = parseBasicAuth(req.headers.get('authorization'));
+  if (basic.clientId && !fields.client_id) {
+    fields.client_id = basic.clientId;
+  }
+  if (basic.clientSecret && !fields.client_secret) {
+    fields.client_secret = basic.clientSecret;
+  }
+
+  return fields;
+}
+
+function parseBasicAuth(header: string | null): {
+  clientId?: string;
+  clientSecret?: string;
+} {
+  if (!header?.startsWith('Basic ')) {
+    return {};
+  }
+
+  try {
+    const decoded = Buffer.from(header.slice(6), 'base64').toString('utf8');
+    const separator = decoded.indexOf(':');
+    if (separator === -1) {
+      return { clientId: decoded };
+    }
+    return {
+      clientId: decoded.slice(0, separator),
+      clientSecret: decoded.slice(separator + 1)
+    };
+  } catch {
+    return {};
+  }
+}

--- a/examples/brain-oauth/shared/config/route.ts
+++ b/examples/brain-oauth/shared/config/route.ts
@@ -23,8 +23,23 @@ export const ROUTE_DASHBOARD_APPS = '/dashboard/apps' as const;
 /** OAuth 2.0 authorization consent page. */
 export const ROUTE_OAUTH_AUTHORIZE = '/oauth/authorize' as const;
 
+/** OAuth 2.0 token endpoint (machine-to-machine, no locale prefix). */
+export const ROUTE_OAUTH_TOKEN = '/oauth/token' as const;
+
+/** OAuth machine endpoints that skip session and locale middleware. */
+export const OAUTH_MACHINE_ROUTES = [ROUTE_OAUTH_TOKEN] as const;
+
 /** Routes that are allowed without authentication (public routes). */
 export const AUTH_ROUTES = [ROUTE_HOME, ROUTE_LOGIN, ROUTE_REGISTER] as const;
+
+/**
+ * Returns true if pathname is an OAuth machine endpoint (token, userinfo, etc.).
+ */
+export function isOAuthMachinePath(pathname: string): boolean {
+  return OAUTH_MACHINE_ROUTES.some(
+    (route) => pathname === route || pathname.endsWith(route)
+  );
+}
 
 /**
  * Returns true if pathname is a public route (no auth required).

--- a/examples/brain-oauth/shared/schemas/oauth/OAuthAuthorizeSchema.ts
+++ b/examples/brain-oauth/shared/schemas/oauth/OAuthAuthorizeSchema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const OAuthClientRowSchema = z.object({
   id: z.number(),
   client_id: z.string(),
+  client_secret_hash: z.string(),
   client_name: z.string(),
   client_uri: z.string().nullable().optional(),
   logo_uri: z.string().nullable().optional(),

--- a/examples/brain-oauth/shared/schemas/oauth/OAuthTokenSchema.ts
+++ b/examples/brain-oauth/shared/schemas/oauth/OAuthTokenSchema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const OAuthTokenAuthorizationCodeSchema = z.object({
+  grant_type: z.literal('authorization_code'),
+  code: z.string().min(1),
+  redirect_uri: z.string().url(),
+  client_id: z.string().min(1),
+  client_secret: z.string().min(1).optional()
+});
+
+export type OAuthTokenAuthorizationCodeRequest = z.infer<
+  typeof OAuthTokenAuthorizationCodeSchema
+>;
+
+export const OAuthTokenRefreshSchema = z.object({
+  grant_type: z.literal('refresh_token'),
+  refresh_token: z.string().min(1),
+  client_id: z.string().min(1),
+  client_secret: z.string().min(1).optional()
+});
+
+export type OAuthTokenRefreshRequest = z.infer<typeof OAuthTokenRefreshSchema>;
+
+export const OAuthTokenRequestSchema = z.discriminatedUnion('grant_type', [
+  OAuthTokenAuthorizationCodeSchema,
+  OAuthTokenRefreshSchema
+]);
+
+export type OAuthTokenRequest = z.infer<typeof OAuthTokenRequestSchema>;
+
+export const OAuthTokenErrorResponseSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional()
+});
+
+export type OAuthTokenErrorResponse = z.infer<
+  typeof OAuthTokenErrorResponseSchema
+>;

--- a/examples/brain-oauth/shared/supabase/proxy.ts
+++ b/examples/brain-oauth/shared/supabase/proxy.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { ROUTE_LOGIN, isPublicPath } from '@config/route';
+import { ROUTE_LOGIN, isOAuthMachinePath, isPublicPath } from '@config/route';
 import {
   BRAIN_SESSION_COOKIE,
   parseBrainSessionCookie
@@ -7,6 +7,11 @@ import {
 
 export async function updateSession(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+
+  if (isOAuthMachinePath(pathname)) {
+    return NextResponse.next({ request });
+  }
+
   const raw = request.cookies.get(BRAIN_SESSION_COOKIE)?.value;
   const session = parseBrainSessionCookie(raw, process.env.SESSION_SECRET);
 

--- a/examples/brain-oauth/src/app/oauth/token/route.ts
+++ b/examples/brain-oauth/src/app/oauth/token/route.ts
@@ -1,0 +1,50 @@
+import { BootstrapServer } from '@server/BootstrapServer';
+import { OAuthTokenController } from '@server/controllers/OAuthTokenController';
+import {
+  OAuthTokenError,
+  oauthTokenErrorResponse
+} from '@server/utils/oauthTokenError';
+import { parseOAuthTokenRequest } from '@server/utils/parseOAuthTokenRequest';
+import type { NextRequest } from 'next/server';
+
+/**
+ * OAuth 2.0 token endpoint (RFC 6749).
+ *
+ * Supports `grant_type=authorization_code` and `grant_type=refresh_token`.
+ * Client authentication via HTTP Basic or form body parameters.
+ */
+export async function POST(req: NextRequest) {
+  let fields: Record<string, string>;
+  try {
+    fields = await parseOAuthTokenRequest(req);
+  } catch {
+    return oauthTokenErrorResponse(
+      new OAuthTokenError('invalid_request', 400, 'Unable to parse request body')
+    );
+  }
+
+  if (!fields.grant_type) {
+    return oauthTokenErrorResponse(
+      new OAuthTokenError('invalid_request', 400, 'grant_type is required')
+    );
+  }
+
+  const IOC = new BootstrapServer('/oauth/token').getIOC();
+
+  try {
+    const tokens = await IOC(OAuthTokenController).exchangeToken(fields);
+
+    return Response.json(tokens, {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' }
+    });
+  } catch (err) {
+    if (err instanceof OAuthTokenError) {
+      return oauthTokenErrorResponse(err);
+    }
+
+    return oauthTokenErrorResponse(
+      new OAuthTokenError('server_error', 500, 'Internal server error')
+    );
+  }
+}

--- a/examples/brain-oauth/src/proxy.ts
+++ b/examples/brain-oauth/src/proxy.ts
@@ -1,19 +1,22 @@
-// src/middleware.ts
-
-// Import the Next.js middleware helper from next-intl
-import createMiddleware from 'next-intl/middleware';
-
 // Import your routing configuration which contains all locales, defaultLocale, and pathnames
+import { isOAuthMachinePath } from '@config/route';
 import { updateSession } from '@shared/supabase/proxy';
 import { routing } from './i18n/routing';
-import type { NextRequest } from 'next/server';
-
-// Export the middleware created by next-intl
-// This middleware will handle locale detection, redirects, and internationalized routing automatically
-// export default createMiddleware(routing);
+import { NextResponse, type NextRequest } from 'next/server';
+import createMiddleware from 'next-intl/middleware';
 
 export default async function proxy(request: NextRequest) {
-  await updateSession(request);
+  const pathname = request.nextUrl.pathname;
+
+  if (isOAuthMachinePath(pathname)) {
+    return NextResponse.next({ request });
+  }
+
+  const sessionResponse = await updateSession(request);
+  if (sessionResponse.headers.get('Location')) {
+    return sessionResponse;
+  }
+
   return createMiddleware(routing)(request);
 }
 


### PR DESCRIPTION
- Added OAuthTokenController to handle token exchange requests at the `/oauth/token` endpoint.
- Developed OAuthTokenService for processing authorization codes and refresh tokens, including validation and error handling.
- Introduced OAuthRefreshTokensRepository for managing refresh tokens, including creation and revocation.
- Implemented utility functions for hashing client secrets and parsing OAuth token requests.
- Enhanced routing configuration to support the new token endpoint and middleware for OAuth machine routes.

This commit establishes a critical component of the OAuth 2.0 flow, enabling secure token exchanges for client applications.