### PR TITLE
feat(brain-oauth): Implement userinfo endpoint for OAuth 2.0

### DIFF
--- a/examples/brain-oauth/server/adapters/BrainUserAdapter.ts
+++ b/examples/brain-oauth/server/adapters/BrainUserAdapter.ts
@@ -82,4 +82,16 @@ export class BrainUserAdapter {
   public getUserInfo(token: string): Promise<BrainCredentials & BrainUser> {
     return this.gateway.getUserInfo({ token });
   }
+
+  /**
+   * Fetches user profile using an OAuth access_token (userly JWT, Bearer scheme).
+   */
+  public getUserInfoByAccessToken(
+    accessToken: string
+  ): Promise<BrainCredentials & BrainUser> {
+    return this.gateway.getUserInfo(
+      { token: accessToken },
+      { tokenPrefix: 'Bearer' }
+    );
+  }
 }

--- a/examples/brain-oauth/server/controllers/OAuthUserInfoController.ts
+++ b/examples/brain-oauth/server/controllers/OAuthUserInfoController.ts
@@ -1,0 +1,17 @@
+import { inject, injectable } from '@shared/container';
+import type { OAuthUserInfoResponse } from '@schemas/oauth/OAuthUserInfoSchema';
+import { OAuthUserInfoService } from '../services/OAuthUserInfoService';
+
+/**
+ * HTTP entry for OAuth userinfo (`GET /userinfo`).
+ */
+@injectable()
+export class OAuthUserInfoController {
+  constructor(
+    @inject(OAuthUserInfoService) protected userInfoService: OAuthUserInfoService
+  ) {}
+
+  public async getUserInfo(accessToken: string): Promise<OAuthUserInfoResponse> {
+    return await this.userInfoService.getUserInfo(accessToken);
+  }
+}

--- a/examples/brain-oauth/server/services/OAuthUserInfoService.ts
+++ b/examples/brain-oauth/server/services/OAuthUserInfoService.ts
@@ -1,0 +1,58 @@
+import type { BrainUser } from '@brain-toolkit/brain-user';
+import { inject, injectable } from '@shared/container';
+import type { OAuthUserInfoResponse } from '@schemas/oauth/OAuthUserInfoSchema';
+import { BrainUserAdapter } from '../adapters/BrainUserAdapter';
+import { OAuthUserInfoError } from '../utils/oauthUserInfoError';
+
+/**
+ * OAuth 2.0 / OIDC userinfo endpoint (`GET /userinfo`).
+ *
+ * Significance: Exposes authenticated user profile to OAuth clients.
+ * Core idea: Validate Bearer access_token and proxy Brain `/users/me.json`.
+ * Main function: Map Brain user profile to standard userinfo claims.
+ * Main purpose: Complete authorization-code flow for third-party apps.
+ *
+ * @example
+ * const profile = await service.getUserInfo('eyJ...');
+ */
+@injectable()
+export class OAuthUserInfoService {
+  constructor(
+    @inject(BrainUserAdapter) protected brainAdapter: BrainUserAdapter
+  ) {}
+
+  public async getUserInfo(accessToken: string): Promise<OAuthUserInfoResponse> {
+    try {
+      const profile = await this.brainAdapter.getUserInfoByAccessToken(
+        accessToken
+      );
+      return this.toUserInfoResponse(profile);
+    } catch {
+      throw new OAuthUserInfoError('invalid_token', 401);
+    }
+  }
+
+  protected toUserInfoResponse(profile: BrainUser): OAuthUserInfoResponse {
+    const sub = String(profile.id);
+    if (!sub || sub === 'NaN') {
+      throw new OAuthUserInfoError('invalid_token', 401);
+    }
+
+    const email = profile.email?.trim();
+    if (!email) {
+      throw new OAuthUserInfoError('invalid_token', 401);
+    }
+
+    const nameFromParts = [profile.first_name, profile.last_name]
+      .filter(Boolean)
+      .join(' ');
+    const name = profile.name?.trim() || nameFromParts || email;
+
+    return {
+      sub,
+      email,
+      name,
+      ...(profile.roles?.length ? { roles: profile.roles } : {})
+    };
+  }
+}

--- a/examples/brain-oauth/server/utils/oauthUserInfoError.ts
+++ b/examples/brain-oauth/server/utils/oauthUserInfoError.ts
@@ -1,0 +1,16 @@
+/**
+ * OAuth 2.0 / OpenID Connect userinfo error response.
+ */
+export class OAuthUserInfoError extends Error {
+  constructor(
+    public readonly error: 'invalid_token',
+    public readonly status: number
+  ) {
+    super(error);
+    this.name = 'OAuthUserInfoError';
+  }
+}
+
+export function oauthUserInfoErrorResponse(err: OAuthUserInfoError): Response {
+  return Response.json({ error: err.error }, { status: err.status });
+}

--- a/examples/brain-oauth/server/utils/parseBearerAuthorization.ts
+++ b/examples/brain-oauth/server/utils/parseBearerAuthorization.ts
@@ -1,0 +1,14 @@
+/**
+ * Extracts a Bearer access token from the Authorization header (RFC 6750).
+ */
+export function parseBearerAuthorization(
+  header: string | null
+): string | undefined {
+  if (!header) {
+    return undefined;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  const token = match?.[1]?.trim();
+  return token || undefined;
+}

--- a/examples/brain-oauth/shared/config/route.ts
+++ b/examples/brain-oauth/shared/config/route.ts
@@ -26,8 +26,14 @@ export const ROUTE_OAUTH_AUTHORIZE = '/oauth/authorize' as const;
 /** OAuth 2.0 token endpoint (machine-to-machine, no locale prefix). */
 export const ROUTE_OAUTH_TOKEN = '/oauth/token' as const;
 
+/** OAuth 2.0 / OIDC userinfo endpoint (machine-to-machine, no locale prefix). */
+export const ROUTE_USERINFO = '/userinfo' as const;
+
 /** OAuth machine endpoints that skip session and locale middleware. */
-export const OAUTH_MACHINE_ROUTES = [ROUTE_OAUTH_TOKEN] as const;
+export const OAUTH_MACHINE_ROUTES = [
+  ROUTE_OAUTH_TOKEN,
+  ROUTE_USERINFO
+] as const;
 
 /** Routes that are allowed without authentication (public routes). */
 export const AUTH_ROUTES = [ROUTE_HOME, ROUTE_LOGIN, ROUTE_REGISTER] as const;

--- a/examples/brain-oauth/shared/schemas/oauth/OAuthUserInfoSchema.ts
+++ b/examples/brain-oauth/shared/schemas/oauth/OAuthUserInfoSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const OAuthUserInfoResponseSchema = z.object({
+  sub: z.string(),
+  email: z.string().email(),
+  name: z.string(),
+  roles: z.array(z.string()).optional()
+});
+
+export type OAuthUserInfoResponse = z.infer<typeof OAuthUserInfoResponseSchema>;
+
+export const OAuthUserInfoErrorResponseSchema = z.object({
+  error: z.literal('invalid_token')
+});
+
+export type OAuthUserInfoErrorResponse = z.infer<
+  typeof OAuthUserInfoErrorResponseSchema
+>;

--- a/examples/brain-oauth/src/app/userinfo/route.ts
+++ b/examples/brain-oauth/src/app/userinfo/route.ts
@@ -1,0 +1,44 @@
+import { BootstrapServer } from '@server/BootstrapServer';
+import { OAuthUserInfoController } from '@server/controllers/OAuthUserInfoController';
+import {
+  OAuthUserInfoError,
+  oauthUserInfoErrorResponse
+} from '@server/utils/oauthUserInfoError';
+import { parseBearerAuthorization } from '@server/utils/parseBearerAuthorization';
+import type { NextRequest } from 'next/server';
+
+/**
+ * OAuth 2.0 / OIDC userinfo endpoint.
+ *
+ * Requires `Authorization: Bearer <access_token>` from `POST /oauth/token`.
+ */
+export async function GET(req: NextRequest) {
+  const accessToken = parseBearerAuthorization(
+    req.headers.get('authorization')
+  );
+
+  if (!accessToken) {
+    return oauthUserInfoErrorResponse(
+      new OAuthUserInfoError('invalid_token', 401)
+    );
+  }
+
+  const IOC = new BootstrapServer('/userinfo').getIOC();
+
+  try {
+    const profile = await IOC(OAuthUserInfoController).getUserInfo(accessToken);
+
+    return Response.json(profile, {
+      status: 200,
+      headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' }
+    });
+  } catch (err) {
+    if (err instanceof OAuthUserInfoError) {
+      return oauthUserInfoErrorResponse(err);
+    }
+
+    return oauthUserInfoErrorResponse(
+      new OAuthUserInfoError('invalid_token', 401)
+    );
+  }
+}


### PR DESCRIPTION
- Added OAuthUserInfoController to handle userinfo requests at the `/userinfo` endpoint.
- Introduced OAuthUserInfoService to validate Bearer access tokens and retrieve user profiles.
- Implemented error handling for invalid tokens using OAuthUserInfoError.
- Created utility functions for parsing Bearer tokens and formatting error responses.
- Updated routing configuration to include the new userinfo endpoint.

This commit enhances the OAuth 2.0 implementation by providing a standardized way to access user profile information for authenticated clients.