### PR TITLE
feat(brain-oauth): Enhance request logging with record type

### DIFF
--- a/examples/brain-oauth/__tests__/helpers/oauthFixtures.ts
+++ b/examples/brain-oauth/__tests__/helpers/oauthFixtures.ts
@@ -1,5 +1,7 @@
-import type { OAuthAuthorizationCodeRow } from '@schemas/oauth/OAuthAuthorizeSchema';
-import type { OAuthClientRow } from '@schemas/oauth/OAuthAuthorizeSchema';
+import type {
+  OAuthAuthorizationCodeRow,
+  OAuthClientRow
+} from '@schemas/oauth/OAuthAuthorizeSchema';
 import type { OAuthRefreshTokenRow } from '@schemas/oauth/OAuthClientSchema';
 import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
 

--- a/examples/brain-oauth/__tests__/routes/oauthTokenRoute.test.ts
+++ b/examples/brain-oauth/__tests__/routes/oauthTokenRoute.test.ts
@@ -1,12 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { POST } from '../../src/app/oauth/token/route';
 
 const exchangeToken = vi.fn();
 
 vi.mock('@server/BootstrapServer', () => ({
   BootstrapServer: class MockBootstrapServer {
-    getIOC() {
+    public getIOC(): unknown {
       return () => ({
         exchangeToken
       });

--- a/examples/brain-oauth/__tests__/routes/userinfoRoute.test.ts
+++ b/examples/brain-oauth/__tests__/routes/userinfoRoute.test.ts
@@ -1,12 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from '../../src/app/userinfo/route';
 
 const getUserInfo = vi.fn();
 
 vi.mock('@server/BootstrapServer', () => ({
   BootstrapServer: class MockBootstrapServer {
-    getIOC() {
+    public getIOC(): unknown {
       return () => ({
         getUserInfo
       });

--- a/examples/brain-oauth/__tests__/services/OAuthTokenService.test.ts
+++ b/examples/brain-oauth/__tests__/services/OAuthTokenService.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { OAuthTokenService } from '@server/services/OAuthTokenService';
-import { OAuthTokenError } from '@server/utils/oauthTokenError';
-import { hashOpaqueToken } from '@server/repositorys/OAuthCredentialsRepository';
-import type { OAuthClientsRepository } from '@server/repositorys/OAuthClientsRepository';
-import type { OAuthAuthorizationCodesRepository } from '@server/repositorys/OAuthAuthorizationCodesRepository';
-import type { OAuthRefreshTokensRepository } from '@server/repositorys/OAuthRefreshTokensRepository';
-import type { OAuthCredentialsRepository } from '@server/repositorys/OAuthCredentialsRepository';
 import type { BrainUserAdapter } from '@server/adapters/BrainUserAdapter';
+import type { OAuthAuthorizationCodesRepository } from '@server/repositorys/OAuthAuthorizationCodesRepository';
+import type { OAuthClientsRepository } from '@server/repositorys/OAuthClientsRepository';
+import { hashOpaqueToken } from '@server/repositorys/OAuthCredentialsRepository';
+import type { OAuthCredentialsRepository } from '@server/repositorys/OAuthCredentialsRepository';
+import type { OAuthRefreshTokensRepository } from '@server/repositorys/OAuthRefreshTokensRepository';
+import { OAuthTokenService } from '@server/services/OAuthTokenService';
+import type { OAuthTokenError } from '@server/utils/oauthTokenError';
 import {
   testAuthCode,
   testOAuthClient,

--- a/examples/brain-oauth/__tests__/services/OAuthUserInfoService.test.ts
+++ b/examples/brain-oauth/__tests__/services/OAuthUserInfoService.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrainUserAdapter } from '@server/adapters/BrainUserAdapter';
 import { OAuthUserInfoService } from '@server/services/OAuthUserInfoService';
 import { OAuthUserInfoError } from '@server/utils/oauthUserInfoError';
-import type { BrainUserAdapter } from '@server/adapters/BrainUserAdapter';
 
 describe('OAuthUserInfoService', () => {
   const brainAdapter = {

--- a/examples/brain-oauth/__tests__/utils/parseOAuthTokenRequest.test.ts
+++ b/examples/brain-oauth/__tests__/utils/parseOAuthTokenRequest.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
 import { parseOAuthTokenRequest } from '@server/utils/parseOAuthTokenRequest';
 
 function formRequest(
@@ -45,9 +45,12 @@ describe('parseOAuthTokenRequest', () => {
   it('does not override body client_id with Basic auth', async () => {
     const basic = Buffer.from('other:secret').toString('base64');
     const fields = await parseOAuthTokenRequest(
-      formRequest('grant_type=refresh_token&refresh_token=rt1&client_id=from_body', {
-        authorization: `Basic ${basic}`
-      })
+      formRequest(
+        'grant_type=refresh_token&refresh_token=rt1&client_id=from_body',
+        {
+          authorization: `Basic ${basic}`
+        }
+      )
     );
 
     expect(fields.client_id).toBe('from_body');

--- a/examples/brain-oauth/makes/sql/001-base-tables.sql
+++ b/examples/brain-oauth/makes/sql/001-base-tables.sql
@@ -9,6 +9,7 @@ create table public.request_logs (
   event_type text not null,
   success boolean not null default true,
   request_id uuid,
+  record_type text,
   payload jsonb
 );
 
@@ -19,6 +20,7 @@ comment on column public.request_logs.updated_at is 'Last update time; append-on
 comment on column public.request_logs.event_category is 'High-level group, e.g. api, auth, system.';
 comment on column public.request_logs.event_type is 'Concrete event, e.g. http.request, login, logout.';
 comment on column public.request_logs.request_id is 'Optional correlation id for an API/request lifecycle (e.g. AppApiResult.requestId); auth-only rows may be null.';
+comment on column public.request_logs.record_type is 'Optional log record kind (e.g. brain-oauth for OAuth-related traffic in this app); null when unspecified.';
 comment on column public.request_logs.payload is 'Event-specific context: HTTP fields, IP, errors, correlation_id, auth_provider, etc.';
 
 create index idx_request_logs_user_id on public.request_logs (user_id);

--- a/examples/brain-oauth/makes/sql/002-request_logs_request_id.sql
+++ b/examples/brain-oauth/makes/sql/002-request_logs_request_id.sql
@@ -1,8 +1,0 @@
--- Add optional request correlation id to existing deployments (idempotent).
-
-alter table public.request_logs
-  add column if not exists request_id uuid;
-
-comment on column public.request_logs.request_id is 'Optional correlation id for an API/request lifecycle (e.g. AppApiResult.requestId); auth-only rows may be null.';
-
-create index if not exists idx_request_logs_request_id on public.request_logs (request_id);

--- a/examples/brain-oauth/server/NextApiServer.ts
+++ b/examples/brain-oauth/server/NextApiServer.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import type { AppApiResult } from '@interfaces/AppApiInterface';
 import { BootstrapServer } from '@server/BootstrapServer';
 import { RequestLogsRepository } from '@server/repositorys/RequestLogsRepository';
+import { resolveBrainOauthRequestLogRecordType } from '@server/utils/requestLogRecordType';
 import { nextApiServerBackstop } from './plugins/nextApiServerBackstop';
 import { ApiResultFactory } from './utils/ApiResultFactory';
 import type {
@@ -62,6 +63,7 @@ export class NextApiServer extends BootstrapServer {
       event_type: 'http.request',
       success,
       request_id: correlationId?.trim() ? correlationId : null,
+      record_type: resolveBrainOauthRequestLogRecordType(req.nextUrl.pathname),
       payload: {
         http_method: req.method,
         http_path: req.nextUrl.pathname,

--- a/examples/brain-oauth/server/controllers/OAuthClientsController.ts
+++ b/examples/brain-oauth/server/controllers/OAuthClientsController.ts
@@ -7,13 +7,13 @@ import type {
   OAuthClientSecretRotateResponseSchema,
   OAuthClientUpdateSchema
 } from '@schemas/oauth/OAuthAuthorizeSchema';
-import { ServerAuth } from '../services/ServerAuth';
 import { OAuthClientsService } from '../services/OAuthClientsService';
+import { ServerAuth } from '../services/ServerAuth';
 import type { ServerAuthInterface } from '../interfaces/ServerAuthInterface';
 
 /**
  * Developer console OAuth clients API controller.
- * 
+ *
  * Manages OAuth client applications for developers.
  */
 @injectable()

--- a/examples/brain-oauth/server/controllers/OAuthTokenController.ts
+++ b/examples/brain-oauth/server/controllers/OAuthTokenController.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from '@shared/container';
-import { OAuthTokenService } from '../services/OAuthTokenService';
 import type { OAuthTokenResponse } from '@schemas/oauth/OAuthClientSchema';
+import { OAuthTokenService } from '../services/OAuthTokenService';
 
 /**
  * HTTP entry for OAuth token exchange (`POST /oauth/token`).

--- a/examples/brain-oauth/server/controllers/OAuthUserInfoController.ts
+++ b/examples/brain-oauth/server/controllers/OAuthUserInfoController.ts
@@ -8,10 +8,13 @@ import { OAuthUserInfoService } from '../services/OAuthUserInfoService';
 @injectable()
 export class OAuthUserInfoController {
   constructor(
-    @inject(OAuthUserInfoService) protected userInfoService: OAuthUserInfoService
+    @inject(OAuthUserInfoService)
+    protected userInfoService: OAuthUserInfoService
   ) {}
 
-  public async getUserInfo(accessToken: string): Promise<OAuthUserInfoResponse> {
+  public async getUserInfo(
+    accessToken: string
+  ): Promise<OAuthUserInfoResponse> {
     return await this.userInfoService.getUserInfo(accessToken);
   }
 }

--- a/examples/brain-oauth/server/interfaces/RequestLogsRepositoryInterface.ts
+++ b/examples/brain-oauth/server/interfaces/RequestLogsRepositoryInterface.ts
@@ -11,6 +11,8 @@ export type RequestLogInsert = {
   success?: boolean;
   /** API/request correlation id when known (e.g. AppApiResult.requestId). */
   request_id?: string | null;
+  /** Optional log record kind (e.g. `brain-oauth`). */
+  record_type?: string | null;
   payload?: Record<string, unknown> | null;
 };
 

--- a/examples/brain-oauth/server/interfaces/ServerInterface.ts
+++ b/examples/brain-oauth/server/interfaces/ServerInterface.ts
@@ -35,9 +35,11 @@ export interface BootstrapServerContextOptions extends BootstrapPluginOptions {
   ctx?: UserLoginContext;
 }
 
-export interface BootstrapServerPlugin extends LifecyclePluginInterface<BootstrapServerContext> {}
+export interface BootstrapServerPlugin
+  extends LifecyclePluginInterface<BootstrapServerContext> {}
 
-export interface BootstrapServerContext extends ExecutorContextInterface<BootstrapServerContextOptions> {}
+export interface BootstrapServerContext
+  extends ExecutorContextInterface<BootstrapServerContextOptions> {}
 
 export interface ServerInterface {
   readonly logger: LoggerInterface;

--- a/examples/brain-oauth/server/render/AppPageRouteParams.ts
+++ b/examples/brain-oauth/server/render/AppPageRouteParams.ts
@@ -18,9 +18,9 @@ export interface PageParamsType {
 /**
  * 用于 src/app/page 路由的参数管理工具
  */
-export class AppPageRouteParams<
-  T extends PageParamsType
-> implements RouteParamsnHandlerInterface {
+export class AppPageRouteParams<T extends PageParamsType>
+  implements RouteParamsnHandlerInterface
+{
   private locale: string | null;
 
   constructor(protected readonly params: T) {

--- a/examples/brain-oauth/server/repositorys/OAuthAuthorizationCodesRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthAuthorizationCodesRepository.ts
@@ -18,15 +18,17 @@ export type CreateAuthorizationCodeInput = {
 export class OAuthAuthorizationCodesRepository {
   public async create(input: CreateAuthorizationCodeInput): Promise<void> {
     const supabase = createAdminClient();
-    const { error } = await supabase.from('brain_oauth_authorization_codes').insert({
-      code: input.code,
-      client_id: input.client_id,
-      user_id: input.user_id,
-      redirect_uri: input.redirect_uri,
-      scope: input.scope,
-      expires_at: input.expires_at,
-      used: false
-    });
+    const { error } = await supabase
+      .from('brain_oauth_authorization_codes')
+      .insert({
+        code: input.code,
+        client_id: input.client_id,
+        user_id: input.user_id,
+        redirect_uri: input.redirect_uri,
+        scope: input.scope,
+        expires_at: input.expires_at,
+        used: false
+      });
 
     if (error) {
       throw new Error(error.message);

--- a/examples/brain-oauth/server/repositorys/OAuthClientsRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthClientsRepository.ts
@@ -1,20 +1,25 @@
 import { injectable } from '@shared/container';
 import { createAdminClient } from '@shared/supabase/admin';
-import { verifyClientSecret, hashClientSecret } from '@server/utils/clientSecretHash';
-import type { OAuthClientRow } from '@schemas/oauth/OAuthAuthorizeSchema';
-import type { 
-  OAuthClientListItem, 
+import type {
+  OAuthClientRow,
+  OAuthClientListItem,
   OAuthClientDetail,
   OAuthClientCreate,
-  OAuthClientUpdate 
+  OAuthClientUpdate
 } from '@schemas/oauth/OAuthAuthorizeSchema';
+import {
+  verifyClientSecret,
+  hashClientSecret
+} from '@server/utils/clientSecretHash';
 
 /**
  * Reads and manages registered OAuth clients from Supabase (service role).
  */
 @injectable()
 export class OAuthClientsRepository {
-  public async findByClientId(clientId: string): Promise<OAuthClientRow | null> {
+  public async findByClientId(
+    clientId: string
+  ): Promise<OAuthClientRow | null> {
     const supabase = createAdminClient();
     const { data, error } = await supabase
       .from('brain_oauth_clients')
@@ -29,11 +34,15 @@ export class OAuthClientsRepository {
     return (data as OAuthClientRow | null) ?? null;
   }
 
-  public async listByOwner(ownerUserId: number): Promise<OAuthClientListItem[]> {
+  public async listByOwner(
+    ownerUserId: number
+  ): Promise<OAuthClientListItem[]> {
     const supabase = createAdminClient();
     const { data, error } = await supabase
       .from('brain_oauth_clients')
-      .select('client_id, client_name, client_uri, logo_uri, redirect_uris, created_at, updated_at')
+      .select(
+        'client_id, client_name, client_uri, logo_uri, redirect_uris, created_at, updated_at'
+      )
       .eq('owner_user_id', ownerUserId)
       .order('created_at', { ascending: false });
 
@@ -49,10 +58,12 @@ export class OAuthClientsRepository {
     input: OAuthClientCreate
   ): Promise<{ client: OAuthClientRow; clientSecret: string }> {
     const supabase = createAdminClient();
-    
+
     // Generate client_id and client_secret
     const clientId = `client_${Math.random().toString(36).substring(2, 15)}`;
-    const clientSecret = Math.random().toString(36).substring(2, 20) + Math.random().toString(36).substring(2, 20);
+    const clientSecret =
+      Math.random().toString(36).substring(2, 20) +
+      Math.random().toString(36).substring(2, 20);
     const clientSecretHash = await hashClientSecret(clientSecret);
 
     const { data, error } = await supabase
@@ -87,7 +98,7 @@ export class OAuthClientsRepository {
     input: OAuthClientUpdate
   ): Promise<OAuthClientDetail> {
     const supabase = createAdminClient();
-    
+
     const { data, error } = await supabase
       .from('brain_oauth_clients')
       .update({
@@ -117,9 +128,11 @@ export class OAuthClientsRepository {
     clientId: string
   ): Promise<{ clientSecret: string }> {
     const supabase = createAdminClient();
-    
+
     // Generate new secret
-    const clientSecret = Math.random().toString(36).substring(2, 20) + Math.random().toString(36).substring(2, 20);
+    const clientSecret =
+      Math.random().toString(36).substring(2, 20) +
+      Math.random().toString(36).substring(2, 20);
     const clientSecretHash = await hashClientSecret(clientSecret);
 
     const { error } = await supabase
@@ -140,7 +153,7 @@ export class OAuthClientsRepository {
 
   public async delete(ownerUserId: number, clientId: string): Promise<void> {
     const supabase = createAdminClient();
-    
+
     const { error } = await supabase
       .from('brain_oauth_clients')
       .delete()

--- a/examples/brain-oauth/server/repositorys/OAuthCredentialsRepository.ts
+++ b/examples/brain-oauth/server/repositorys/OAuthCredentialsRepository.ts
@@ -36,14 +36,16 @@ export class OAuthCredentialsRepository {
     }
   ): Promise<void> {
     const supabase = createAdminClient();
-    const { error } = await supabase.from('brain_oauth_user_credentials').upsert(
-      {
-        user_id: userId,
-        ...fields,
-        updated_at: new Date().toISOString()
-      },
-      { onConflict: 'user_id' }
-    );
+    const { error } = await supabase
+      .from('brain_oauth_user_credentials')
+      .upsert(
+        {
+          user_id: userId,
+          ...fields,
+          updated_at: new Date().toISOString()
+        },
+        { onConflict: 'user_id' }
+      );
 
     if (error) {
       throw new Error(error.message);

--- a/examples/brain-oauth/server/repositorys/RequestLogsRepository.ts
+++ b/examples/brain-oauth/server/repositorys/RequestLogsRepository.ts
@@ -89,6 +89,7 @@ export class RequestLogsRepository
           event_type: row.event_type,
           success: row.success ?? true,
           request_id: row.request_id ?? null,
+          record_type: row.record_type ?? null,
           payload: row.payload ?? null
         }
       });

--- a/examples/brain-oauth/server/services/BrainAuthService.ts
+++ b/examples/brain-oauth/server/services/BrainAuthService.ts
@@ -1,9 +1,9 @@
 import { inject, injectable } from '@shared/container';
 import { I } from '@config/ioc-identifiter';
 import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
+import { BrainSessionService } from './BrainSessionService';
 import { BrainUserAdapter } from '../adapters/BrainUserAdapter';
 import { OAuthCredentialsRepository } from '../repositorys/OAuthCredentialsRepository';
-import { BrainSessionService } from './BrainSessionService';
 import { TokenEncryption } from '../utils/TokenEncryption';
 import type {
   BrainAuthServiceInterface,

--- a/examples/brain-oauth/server/services/BrainSessionService.ts
+++ b/examples/brain-oauth/server/services/BrainSessionService.ts
@@ -20,7 +20,9 @@ export type { BrainSessionPayload };
  */
 @injectable()
 export class BrainSessionService {
-  constructor(@inject(I.AppConfig) protected config: SeedServerConfigInterface) {}
+  constructor(
+    @inject(I.AppConfig) protected config: SeedServerConfigInterface
+  ) {}
 
   public async setSession(payload: BrainSessionPayload): Promise<void> {
     const secret = this.requireSecret();

--- a/examples/brain-oauth/server/services/OAuthAuthorizeService.ts
+++ b/examples/brain-oauth/server/services/OAuthAuthorizeService.ts
@@ -1,10 +1,8 @@
 import { inject, injectable } from '@shared/container';
-import { OAuthClientsRepository } from '../repositorys/OAuthClientsRepository';
-import {
-  OAuthAuthorizeQueryValidator
-} from '@shared/validators/OAuthAuthorizeValidator';
-import { parseScopeList } from '../utils/oauthRedirectUtils';
+import { OAuthAuthorizeQueryValidator } from '@shared/validators/OAuthAuthorizeValidator';
 import type { OAuthClientRow } from '@schemas/oauth/OAuthAuthorizeSchema';
+import { OAuthClientsRepository } from '../repositorys/OAuthClientsRepository';
+import { parseScopeList } from '../utils/oauthRedirectUtils';
 
 export type OAuthAuthorizePageData = {
   clientId: string;
@@ -43,7 +41,8 @@ export class OAuthAuthorizeService {
   public async resolveAuthorizePage(
     rawQuery: Record<string, string | string[] | undefined>
   ): Promise<
-    { ok: true; data: OAuthAuthorizePageData } | { ok: false; error: OAuthAuthorizeValidationError }
+    | { ok: true; data: OAuthAuthorizePageData }
+    | { ok: false; error: OAuthAuthorizeValidationError }
   > {
     const query = this.normalizeQuery(rawQuery);
 

--- a/examples/brain-oauth/server/services/OAuthClientsService.ts
+++ b/examples/brain-oauth/server/services/OAuthClientsService.ts
@@ -1,13 +1,14 @@
 import { inject, injectable } from '@shared/container';
-import { OAuthClientsRepository } from '../repositorys/OAuthClientsRepository';
 import type {
   OAuthClientListItem,
   OAuthClientDetail,
+  OAuthClientRow,
   OAuthClientCreate,
   OAuthClientUpdate,
   OAuthClientCreateResponse,
   OAuthClientSecretRotateResponse
 } from '@schemas/oauth/OAuthAuthorizeSchema';
+import { OAuthClientsRepository } from '../repositorys/OAuthClientsRepository';
 
 /**
  * Business logic for OAuth client management in developer console.
@@ -22,7 +23,9 @@ export class OAuthClientsService {
   /**
    * List all OAuth clients owned by a user
    */
-  public async listForOwner(ownerUserId: number): Promise<OAuthClientListItem[]> {
+  public async listForOwner(
+    ownerUserId: number
+  ): Promise<OAuthClientListItem[]> {
     return this.clientsRepo.listByOwner(ownerUserId);
   }
 
@@ -34,7 +37,7 @@ export class OAuthClientsService {
     clientId: string
   ): Promise<OAuthClientDetail> {
     const client = await this.clientsRepo.findByClientId(clientId);
-    
+
     if (!client) {
       throw new Error('Client not found');
     }
@@ -125,7 +128,7 @@ export class OAuthClientsService {
     await this.clientsRepo.delete(ownerUserId, clientId);
   }
 
-  private mapToDetail(row: any): OAuthClientDetail {
+  private mapToDetail(row: OAuthClientRow): OAuthClientDetail {
     return {
       client_id: row.client_id,
       client_name: row.client_name,

--- a/examples/brain-oauth/server/services/OAuthConsentService.ts
+++ b/examples/brain-oauth/server/services/OAuthConsentService.ts
@@ -1,14 +1,12 @@
 import { randomBytes } from 'crypto';
 import { ExecutorError } from '@qlover/fe-corekit';
 import { inject, injectable } from '@shared/container';
+import { OAuthConsentBodyValidator } from '@shared/validators/OAuthAuthorizeValidator';
+import type { OAuthConsentBody } from '@schemas/oauth/OAuthAuthorizeSchema';
+import { BrainSessionService } from './BrainSessionService';
 import { OAuthAuthorizeService } from './OAuthAuthorizeService';
 import { OAuthAuthorizationCodesRepository } from '../repositorys/OAuthAuthorizationCodesRepository';
-import { BrainSessionService } from './BrainSessionService';
-import {
-  OAuthConsentBodyValidator
-} from '@shared/validators/OAuthAuthorizeValidator';
 import { buildOAuthRedirectUrl } from '../utils/oauthRedirectUtils';
-import type { OAuthConsentBody } from '@schemas/oauth/OAuthAuthorizeSchema';
 
 export type OAuthConsentResult = {
   redirectUrl: string;
@@ -69,7 +67,10 @@ export class OAuthConsentService {
     });
 
     if (!pageResult.ok) {
-      throw new ExecutorError(pageResult.error.errorKey, pageResult.error.message);
+      throw new ExecutorError(
+        pageResult.error.errorKey,
+        pageResult.error.message
+      );
     }
 
     const { data } = pageResult;

--- a/examples/brain-oauth/server/services/OAuthTokenService.ts
+++ b/examples/brain-oauth/server/services/OAuthTokenService.ts
@@ -1,12 +1,12 @@
 import { randomBytes } from 'crypto';
 import { inject, injectable } from '@shared/container';
 import { I } from '@config/ioc-identifiter';
-import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
+import type { OAuthTokenResponse } from '@schemas/oauth/OAuthClientSchema';
 import {
   OAuthTokenRequestSchema,
   type OAuthTokenRequest
 } from '@schemas/oauth/OAuthTokenSchema';
-import type { OAuthTokenResponse } from '@schemas/oauth/OAuthClientSchema';
+import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
 import { BrainUserAdapter } from '../adapters/BrainUserAdapter';
 import { OAuthAuthorizationCodesRepository } from '../repositorys/OAuthAuthorizationCodesRepository';
 import { OAuthClientsRepository } from '../repositorys/OAuthClientsRepository';
@@ -134,7 +134,11 @@ export class OAuthTokenService {
       stored.client_id !== verifiedClientId ||
       new Date(stored.expires_at) <= new Date()
     ) {
-      throw new OAuthTokenError('invalid_grant', 400, 'Refresh token is invalid');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        400,
+        'Refresh token is invalid'
+      );
     }
 
     const brainTokens = await this.fetchBrainAccessToken(stored.user_id);
@@ -175,7 +179,9 @@ export class OAuthTokenService {
 
       if (access.refresh_token) {
         await this.credentialsRepo.upsertUserCredentials(userId, {
-          brain_refresh_token: this.tokenEncryption.encrypt(access.refresh_token)
+          brain_refresh_token: this.tokenEncryption.encrypt(
+            access.refresh_token
+          )
         });
       }
 

--- a/examples/brain-oauth/server/services/OAuthUserInfoService.ts
+++ b/examples/brain-oauth/server/services/OAuthUserInfoService.ts
@@ -1,8 +1,8 @@
-import type { BrainUser } from '@brain-toolkit/brain-user';
 import { inject, injectable } from '@shared/container';
 import type { OAuthUserInfoResponse } from '@schemas/oauth/OAuthUserInfoSchema';
 import { BrainUserAdapter } from '../adapters/BrainUserAdapter';
 import { OAuthUserInfoError } from '../utils/oauthUserInfoError';
+import type { BrainUser } from '@brain-toolkit/brain-user';
 
 /**
  * OAuth 2.0 / OIDC userinfo endpoint (`GET /userinfo`).
@@ -21,11 +21,12 @@ export class OAuthUserInfoService {
     @inject(BrainUserAdapter) protected brainAdapter: BrainUserAdapter
   ) {}
 
-  public async getUserInfo(accessToken: string): Promise<OAuthUserInfoResponse> {
+  public async getUserInfo(
+    accessToken: string
+  ): Promise<OAuthUserInfoResponse> {
     try {
-      const profile = await this.brainAdapter.getUserInfoByAccessToken(
-        accessToken
-      );
+      const profile =
+        await this.brainAdapter.getUserInfoByAccessToken(accessToken);
       return this.toUserInfoResponse(profile);
     } catch {
       throw new OAuthUserInfoError('invalid_token', 401);

--- a/examples/brain-oauth/server/services/ServerAuth.ts
+++ b/examples/brain-oauth/server/services/ServerAuth.ts
@@ -5,8 +5,8 @@ import { API_NOT_AUTHORIZED } from '@config/i18n-identifier/api';
 import { I } from '@config/ioc-identifiter';
 import { UserSchema } from '@schemas/UserSchema';
 import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
-import { brainSessionToUserSchema } from '../utils/brainSessionUtils';
 import { BrainSessionService } from './BrainSessionService';
+import { brainSessionToUserSchema } from '../utils/brainSessionUtils';
 import type { ServerAuthInterface } from '../interfaces/ServerAuthInterface';
 
 @injectable()

--- a/examples/brain-oauth/server/services/UserService.ts
+++ b/examples/brain-oauth/server/services/UserService.ts
@@ -4,11 +4,11 @@ import { API_USER_NOT_FOUND } from '@config/i18n-identifier/api';
 import { I } from '@config/ioc-identifiter';
 import type { UserSchema } from '@schemas/UserSchema';
 import type { SeedServerConfigInterface } from '@interfaces/SeedConfigInterface';
-import { brainSessionToUserSchema } from '../utils/brainSessionUtils';
 import { BrainAuthService } from './BrainAuthService';
 import { BrainSessionService } from './BrainSessionService';
 import { ServerAuth } from './ServerAuth';
 import { RequestLogsRepository } from '../repositorys/RequestLogsRepository';
+import { brainSessionToUserSchema } from '../utils/brainSessionUtils';
 import { PasswordEncrypt } from '../utils/PasswordEncrypt';
 import type { BrainAuthServiceInterface } from '../interfaces/BrainAuthServiceInterface';
 import type { RequestLogsRepositoryInterface } from '../interfaces/RequestLogsRepositoryInterface';
@@ -79,7 +79,10 @@ export class UserService implements UserServiceInterface {
 
     const session = await this.brainSession.getSession();
     if (!session) {
-      throw new ExecutorError(API_USER_NOT_FOUND, 'Brain session missing after login');
+      throw new ExecutorError(
+        API_USER_NOT_FOUND,
+        'Brain session missing after login'
+      );
     }
 
     return brainSessionToUserSchema(session, this.appConfig.adminUserIds);

--- a/examples/brain-oauth/server/utils/brainSessionUtils.ts
+++ b/examples/brain-oauth/server/utils/brainSessionUtils.ts
@@ -31,7 +31,9 @@ export function brainSessionToUserSchema(
   return {
     id: String(session.userId),
     email: session.email,
-    role: adminUserIds.includes(session.userId) ? UserRole.ADMIN : UserRole.USER,
+    role: adminUserIds.includes(session.userId)
+      ? UserRole.ADMIN
+      : UserRole.USER,
     password: '',
     credential_token: session.brainToken,
     created_at: new Date().toISOString(),

--- a/examples/brain-oauth/server/utils/logRequestEvent.ts
+++ b/examples/brain-oauth/server/utils/logRequestEvent.ts
@@ -1,7 +1,7 @@
-import type { NextRequest } from 'next/server';
 import { REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH } from '@schemas/RequestLogSchema';
 import type { BootstrapServer } from '@server/BootstrapServer';
 import { RequestLogsRepository } from '@server/repositorys/RequestLogsRepository';
+import type { NextRequest } from 'next/server';
 
 export type LogRequestEventInput = {
   event_category: string;
@@ -17,7 +17,9 @@ export type LogRequestEventInput = {
 
 function clientIp(req: NextRequest): string | null {
   const forwarded = req.headers.get('x-forwarded-for');
-  return forwarded?.split(',')[0]?.trim() || req.headers.get('x-real-ip') || null;
+  return (
+    forwarded?.split(',')[0]?.trim() || req.headers.get('x-real-ip') || null
+  );
 }
 
 /**
@@ -31,21 +33,23 @@ export function logRequestEvent(
   const requestId = input.request_id?.trim() ? input.request_id : null;
   const httpPath = input.http_path ?? req.nextUrl.pathname;
 
-  void server.getIOC()(RequestLogsRepository).insertEvent({
-    event_category: input.event_category,
-    event_type: input.event_type,
-    success: input.success,
-    request_id: requestId,
-    record_type: REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH,
-    payload: {
-      http_method: input.http_method ?? req.method,
-      http_path: httpPath,
-      http_status: input.http_status ?? null,
-      duration_ms: input.duration_ms ?? null,
-      user_agent: req.headers.get('user-agent'),
-      ip_address: clientIp(req),
-      correlation_id: requestId,
-      ...input.payload
-    }
-  });
+  void server
+    .getIOC()(RequestLogsRepository)
+    .insertEvent({
+      event_category: input.event_category,
+      event_type: input.event_type,
+      success: input.success,
+      request_id: requestId,
+      record_type: REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH,
+      payload: {
+        http_method: input.http_method ?? req.method,
+        http_path: httpPath,
+        http_status: input.http_status ?? null,
+        duration_ms: input.duration_ms ?? null,
+        user_agent: req.headers.get('user-agent'),
+        ip_address: clientIp(req),
+        correlation_id: requestId,
+        ...input.payload
+      }
+    });
 }

--- a/examples/brain-oauth/server/utils/logRequestEvent.ts
+++ b/examples/brain-oauth/server/utils/logRequestEvent.ts
@@ -1,0 +1,51 @@
+import type { NextRequest } from 'next/server';
+import { REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH } from '@schemas/RequestLogSchema';
+import type { BootstrapServer } from '@server/BootstrapServer';
+import { RequestLogsRepository } from '@server/repositorys/RequestLogsRepository';
+
+export type LogRequestEventInput = {
+  event_category: string;
+  event_type: string;
+  success: boolean;
+  http_method?: string;
+  http_path?: string;
+  http_status?: number;
+  duration_ms?: number;
+  request_id?: string | null;
+  payload?: Record<string, unknown> | null;
+};
+
+function clientIp(req: NextRequest): string | null {
+  const forwarded = req.headers.get('x-forwarded-for');
+  return forwarded?.split(',')[0]?.trim() || req.headers.get('x-real-ip') || null;
+}
+
+/**
+ * Best-effort OAuth / protocol endpoint log with {@link REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH}.
+ */
+export function logRequestEvent(
+  server: BootstrapServer,
+  req: NextRequest,
+  input: LogRequestEventInput
+): void {
+  const requestId = input.request_id?.trim() ? input.request_id : null;
+  const httpPath = input.http_path ?? req.nextUrl.pathname;
+
+  void server.getIOC()(RequestLogsRepository).insertEvent({
+    event_category: input.event_category,
+    event_type: input.event_type,
+    success: input.success,
+    request_id: requestId,
+    record_type: REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH,
+    payload: {
+      http_method: input.http_method ?? req.method,
+      http_path: httpPath,
+      http_status: input.http_status ?? null,
+      duration_ms: input.duration_ms ?? null,
+      user_agent: req.headers.get('user-agent'),
+      ip_address: clientIp(req),
+      correlation_id: requestId,
+      ...input.payload
+    }
+  });
+}

--- a/examples/brain-oauth/server/utils/oauthRedirectUtils.ts
+++ b/examples/brain-oauth/server/utils/oauthRedirectUtils.ts
@@ -21,8 +21,5 @@ export function parseScopeList(scope: string | undefined): string[] {
     return ['openid', 'profile', 'email'];
   }
 
-  return scope
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
+  return scope.trim().split(/\s+/).filter(Boolean);
 }

--- a/examples/brain-oauth/server/utils/requestLogRecordType.ts
+++ b/examples/brain-oauth/server/utils/requestLogRecordType.ts
@@ -1,0 +1,20 @@
+import { REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH } from '@schemas/RequestLogSchema';
+
+/**
+ * Returns {@link REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH} when `pathname` is an OAuth-related route in this app.
+ */
+export function resolveBrainOauthRequestLogRecordType(
+  pathname: string
+): typeof REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH | null {
+  const path = pathname.split('?')[0]?.replace(/\/+$/, '') || '/';
+  if (
+    path === '/userinfo' ||
+    path.startsWith('/oauth') ||
+    path.startsWith('/api/oauth') ||
+    path.startsWith('/api/clients') ||
+    path.startsWith('/api/brain')
+  ) {
+    return REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH;
+  }
+  return null;
+}

--- a/examples/brain-oauth/shared/config/i18n-identifier/pages/page.developer.apps.ts
+++ b/examples/brain-oauth/shared/config/i18n-identifier/pages/page.developer.apps.ts
@@ -45,7 +45,8 @@ export const DEVELOPER_APPS_DELETE_BUTTON = 'developer_apps:delete_button';
  * @localZh 重置密钥
  * @localEn Rotate Secret
  */
-export const DEVELOPER_APPS_ROTATE_SECRET_BUTTON = 'developer_apps:rotate_secret_button';
+export const DEVELOPER_APPS_ROTATE_SECRET_BUTTON =
+  'developer_apps:rotate_secret_button';
 
 /**
  * @description Client ID label
@@ -59,14 +60,16 @@ export const DEVELOPER_APPS_CLIENT_ID_LABEL = 'developer_apps:client_id_label';
  * @localZh 重定向 URI
  * @localEn Redirect URIs
  */
-export const DEVELOPER_APPS_REDIRECT_URIS_LABEL = 'developer_apps:redirect_uris_label';
+export const DEVELOPER_APPS_REDIRECT_URIS_LABEL =
+  'developer_apps:redirect_uris_label';
 
 /**
  * @description Created at label
  * @localZh 创建于
  * @localEn Created at
  */
-export const DEVELOPER_APPS_CREATED_AT_LABEL = 'developer_apps:created_at_label';
+export const DEVELOPER_APPS_CREATED_AT_LABEL =
+  'developer_apps:created_at_label';
 
 /**
  * @description Status enabled badge text
@@ -80,14 +83,16 @@ export const DEVELOPER_APPS_STATUS_ENABLED = 'developer_apps:status_enabled';
  * @localZh 创建 OAuth 应用
  * @localEn Create OAuth Application
  */
-export const DEVELOPER_APPS_CREATE_MODAL_TITLE = 'developer_apps:create_modal_title';
+export const DEVELOPER_APPS_CREATE_MODAL_TITLE =
+  'developer_apps:create_modal_title';
 
 /**
  * @description Edit modal title
  * @localZh 编辑应用
  * @localEn Edit Application
  */
-export const DEVELOPER_APPS_EDIT_MODAL_TITLE = 'developer_apps:edit_modal_title';
+export const DEVELOPER_APPS_EDIT_MODAL_TITLE =
+  'developer_apps:edit_modal_title';
 
 /**
  * @description Application name form label
@@ -101,28 +106,32 @@ export const DEVELOPER_APPS_APP_NAME_LABEL = 'developer_apps:app_name_label';
  * @localZh 请输入应用名称
  * @localEn Please enter application name
  */
-export const DEVELOPER_APPS_APP_NAME_REQUIRED = 'developer_apps:app_name_required';
+export const DEVELOPER_APPS_APP_NAME_REQUIRED =
+  'developer_apps:app_name_required';
 
 /**
  * @description Redirect URIs textarea placeholder
  * @localZh https://your-app.com/callback\nhttps://localhost:3000/callback
  * @localEn https://your-app.com/callback\nhttps://localhost:3000/callback
  */
-export const DEVELOPER_APPS_REDIRECT_URIS_PLACEHOLDER = 'developer_apps:redirect_uris_placeholder';
+export const DEVELOPER_APPS_REDIRECT_URIS_PLACEHOLDER =
+  'developer_apps:redirect_uris_placeholder';
 
 /**
  * @description Redirect URIs hint text
  * @localZh 支持多个回调地址，每行一个，必须使用 HTTPS (本地开发可用 http://localhost)。
  * @localEn Multiple callback URLs supported, one per line. Must use HTTPS (http://localhost allowed for local development).
  */
-export const DEVELOPER_APPS_REDIRECT_URIS_HINT = 'developer_apps:redirect_uris_hint';
+export const DEVELOPER_APPS_REDIRECT_URIS_HINT =
+  'developer_apps:redirect_uris_hint';
 
 /**
  * @description Client URI form label
  * @localZh 应用主页 URL (可选)
  * @localEn Application Homepage URL (Optional)
  */
-export const DEVELOPER_APPS_CLIENT_URI_LABEL = 'developer_apps:client_uri_label';
+export const DEVELOPER_APPS_CLIENT_URI_LABEL =
+  'developer_apps:client_uri_label';
 
 /**
  * @description Cancel button text
@@ -136,70 +145,80 @@ export const DEVELOPER_APPS_CANCEL_BUTTON = 'developer_apps:cancel_button';
  * @localZh 创建应用
  * @localEn Create Application
  */
-export const DEVELOPER_APPS_CREATE_SUBMIT_BUTTON = 'developer_apps:create_submit_button';
+export const DEVELOPER_APPS_CREATE_SUBMIT_BUTTON =
+  'developer_apps:create_submit_button';
 
 /**
  * @description Save submit button text
  * @localZh 保存修改
  * @localEn Save Changes
  */
-export const DEVELOPER_APPS_SAVE_SUBMIT_BUTTON = 'developer_apps:save_submit_button';
+export const DEVELOPER_APPS_SAVE_SUBMIT_BUTTON =
+  'developer_apps:save_submit_button';
 
 /**
  * @description Delete confirmation dialog title
  * @localZh 删除应用
  * @localEn Delete Application
  */
-export const DEVELOPER_APPS_DELETE_CONFIRM_TITLE = 'developer_apps:delete_confirm_title';
+export const DEVELOPER_APPS_DELETE_CONFIRM_TITLE =
+  'developer_apps:delete_confirm_title';
 
 /**
  * @description Delete confirmation dialog content
  * @localZh 永久删除该应用？此操作不可恢复。
  * @localEn Permanently delete this application? This action cannot be undone.
  */
-export const DEVELOPER_APPS_DELETE_CONFIRM_CONTENT = 'developer_apps:delete_confirm_content';
+export const DEVELOPER_APPS_DELETE_CONFIRM_CONTENT =
+  'developer_apps:delete_confirm_content';
 
 /**
  * @description Rotate secret confirmation dialog title
  * @localZh 重置密钥
  * @localEn Rotate Secret
  */
-export const DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_TITLE = 'developer_apps:rotate_secret_confirm_title';
+export const DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_TITLE =
+  'developer_apps:rotate_secret_confirm_title';
 
 /**
  * @description Rotate secret confirmation dialog content
  * @localZh 重置密钥将导致旧密钥立即失效，确定继续吗？
  * @localEn Rotating the secret will immediately invalidate the old one. Continue?
  */
-export const DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_CONTENT = 'developer_apps:rotate_secret_confirm_content';
+export const DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_CONTENT =
+  'developer_apps:rotate_secret_confirm_content';
 
 /**
  * @description Toast message for successful app creation
  * @localZh 应用创建成功！
  * @localEn Application created successfully!
  */
-export const DEVELOPER_APPS_TOAST_CREATE_SUCCESS = 'developer_apps:toast_create_success';
+export const DEVELOPER_APPS_TOAST_CREATE_SUCCESS =
+  'developer_apps:toast_create_success';
 
 /**
  * @description Toast message for successful app update
  * @localZh 应用信息已更新
  * @localEn Application updated successfully
  */
-export const DEVELOPER_APPS_TOAST_UPDATE_SUCCESS = 'developer_apps:toast_update_success';
+export const DEVELOPER_APPS_TOAST_UPDATE_SUCCESS =
+  'developer_apps:toast_update_success';
 
 /**
  * @description Toast message for successful app deletion
  * @localZh 应用已删除
  * @localEn Application deleted
  */
-export const DEVELOPER_APPS_TOAST_DELETE_SUCCESS = 'developer_apps:toast_delete_success';
+export const DEVELOPER_APPS_TOAST_DELETE_SUCCESS =
+  'developer_apps:toast_delete_success';
 
 /**
  * @description Toast message for successful secret rotation
  * @localZh 新密钥已生成，请妥善保存
  * @localEn New secret generated, please save it securely
  */
-export const DEVELOPER_APPS_TOAST_ROTATE_SUCCESS = 'developer_apps:toast_rotate_success';
+export const DEVELOPER_APPS_TOAST_ROTATE_SUCCESS =
+  'developer_apps:toast_rotate_success';
 
 /**
  * @description Toast message for operation error
@@ -220,7 +239,8 @@ export const DEVELOPER_APPS_EMPTY_STATE = 'developer_apps:empty_state';
  * @localZh 开发者控制台
  * @localEn Developer Console
  */
-export const DEVELOPER_APPS_CONSOLE_SUBTITLE = 'developer_apps:console_subtitle';
+export const DEVELOPER_APPS_CONSOLE_SUBTITLE =
+  'developer_apps:console_subtitle';
 
 /**
  * @description Credentials modal title after create or rotate secret

--- a/examples/brain-oauth/shared/config/i18n-identifier/pages/page.oauth-playground.ts
+++ b/examples/brain-oauth/shared/config/i18n-identifier/pages/page.oauth-playground.ts
@@ -171,8 +171,7 @@ export const PAGE_OAUTH_PLAYGROUND_DENY = 'page_oauth_playground:deny';
  * @localZh 换取 access_token
  * @localEn Exchange access_token
  */
-export const PAGE_OAUTH_PLAYGROUND_EXCHANGE =
-  'page_oauth_playground:exchange';
+export const PAGE_OAUTH_PLAYGROUND_EXCHANGE = 'page_oauth_playground:exchange';
 
 /**
  * @description Fetch userinfo button
@@ -187,24 +186,21 @@ export const PAGE_OAUTH_PLAYGROUND_FETCH_USERINFO =
  * @localZh 模拟回调结果（未外跳）
  * @localEn Simulated callback (no redirect)
  */
-export const PAGE_OAUTH_PLAYGROUND_CALLBACK =
-  'page_oauth_playground:callback';
+export const PAGE_OAUTH_PLAYGROUND_CALLBACK = 'page_oauth_playground:callback';
 
 /**
  * @description Response label
  * @localZh 响应
  * @localEn Response
  */
-export const PAGE_OAUTH_PLAYGROUND_RESPONSE =
-  'page_oauth_playground:response';
+export const PAGE_OAUTH_PLAYGROUND_RESPONSE = 'page_oauth_playground:response';
 
 /**
  * @description Validation ok
  * @localZh 参数有效，可进行授权。
  * @localEn Parameters are valid. You can authorize.
  */
-export const PAGE_OAUTH_PLAYGROUND_VALID_OK =
-  'page_oauth_playground:valid__ok';
+export const PAGE_OAUTH_PLAYGROUND_VALID_OK = 'page_oauth_playground:valid__ok';
 
 /**
  * @description Copy
@@ -226,8 +222,7 @@ export const PAGE_OAUTH_PLAYGROUND_RANDOM_STATE =
  * @localZh OAuth 测试台
  * @localEn OAuth playground
  */
-export const PAGE_OAUTH_PLAYGROUND_NAV_LINK =
-  'page_oauth_playground:nav__link';
+export const PAGE_OAUTH_PLAYGROUND_NAV_LINK = 'page_oauth_playground:nav__link';
 
 /**
  * @description Footer note about simulated redirect

--- a/examples/brain-oauth/shared/config/i18n-mapping/developerAppsI18n.ts
+++ b/examples/brain-oauth/shared/config/i18n-mapping/developerAppsI18n.ts
@@ -1,6 +1,6 @@
+import * as commonKeys from '../i18n-identifier/common/common';
 import * as developerAppsKeys from '../i18n-identifier/pages/page.developer.apps';
 import { PAGE_HOME_TITLE } from '../i18n-identifier/pages/page.home';
-import * as commonKeys from '../i18n-identifier/common/common';
 
 export const developerAppsI18n = Object.freeze({
   // basic meta properties
@@ -30,7 +30,8 @@ export const developerAppsI18n = Object.freeze({
   // form fields
   appNameLabel: developerAppsKeys.DEVELOPER_APPS_APP_NAME_LABEL,
   appNameRequired: developerAppsKeys.DEVELOPER_APPS_APP_NAME_REQUIRED,
-  redirectUrisPlaceholder: developerAppsKeys.DEVELOPER_APPS_REDIRECT_URIS_PLACEHOLDER,
+  redirectUrisPlaceholder:
+    developerAppsKeys.DEVELOPER_APPS_REDIRECT_URIS_PLACEHOLDER,
   redirectUrisHint: developerAppsKeys.DEVELOPER_APPS_REDIRECT_URIS_HINT,
   clientUriLabel: developerAppsKeys.DEVELOPER_APPS_CLIENT_URI_LABEL,
 
@@ -42,8 +43,10 @@ export const developerAppsI18n = Object.freeze({
   // confirmations
   deleteConfirmTitle: developerAppsKeys.DEVELOPER_APPS_DELETE_CONFIRM_TITLE,
   deleteConfirmContent: developerAppsKeys.DEVELOPER_APPS_DELETE_CONFIRM_CONTENT,
-  rotateSecretConfirmTitle: developerAppsKeys.DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_TITLE,
-  rotateSecretConfirmContent: developerAppsKeys.DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_CONTENT,
+  rotateSecretConfirmTitle:
+    developerAppsKeys.DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_TITLE,
+  rotateSecretConfirmContent:
+    developerAppsKeys.DEVELOPER_APPS_ROTATE_SECRET_CONFIRM_CONTENT,
 
   // toasts
   toastCreateSuccess: developerAppsKeys.DEVELOPER_APPS_TOAST_CREATE_SUCCESS,
@@ -56,7 +59,8 @@ export const developerAppsI18n = Object.freeze({
   emptyState: developerAppsKeys.DEVELOPER_APPS_EMPTY_STATE,
 
   consoleSubtitle: developerAppsKeys.DEVELOPER_APPS_CONSOLE_SUBTITLE,
-  credentialsModalTitle: developerAppsKeys.DEVELOPER_APPS_CREDENTIALS_MODAL_TITLE,
+  credentialsModalTitle:
+    developerAppsKeys.DEVELOPER_APPS_CREDENTIALS_MODAL_TITLE,
   clientSecretLabel: developerAppsKeys.DEVELOPER_APPS_CLIENT_SECRET_LABEL,
   secretWarning: developerAppsKeys.DEVELOPER_APPS_SECRET_WARNING,
   credentialsConfirm: developerAppsKeys.DEVELOPER_APPS_CREDENTIALS_CONFIRM,

--- a/examples/brain-oauth/shared/interfaces/UserServiceInterface.ts
+++ b/examples/brain-oauth/shared/interfaces/UserServiceInterface.ts
@@ -4,10 +4,8 @@ import type {
   UserServiceGateway
 } from '@qlover/corekit-bridge';
 
-export interface UserServiceInterface extends CorekitBridgeUserServiceInterface<
-  UserSchema,
-  UserCredential
-> {
+export interface UserServiceInterface
+  extends CorekitBridgeUserServiceInterface<UserSchema, UserCredential> {
   // You can add your own methods here
 
   /**
@@ -18,8 +16,5 @@ export interface UserServiceInterface extends CorekitBridgeUserServiceInterface<
   getToken(): string;
 }
 
-export interface UserServiceGatewayInterface extends UserServiceGateway<
-  UserSchema,
-  UserCredential,
-  {}
-> {}
+export interface UserServiceGatewayInterface
+  extends UserServiceGateway<UserSchema, UserCredential, {}> {}

--- a/examples/brain-oauth/shared/schemas/RequestLogSchema.ts
+++ b/examples/brain-oauth/shared/schemas/RequestLogSchema.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+/** `request_logs.record_type` for rows emitted by the brain-oauth example app. */
+export const REQUEST_LOG_RECORD_TYPE_BRAIN_OAUTH = 'brain-oauth';
+
 /** Optional keys written into `payload` by server code (UI may read these). */
 export type RequestLogPayload = {
   http_method?: string | null;
@@ -26,6 +29,7 @@ export const requestLogRowSchema = z.object({
   event_type: z.string(),
   success: z.boolean(),
   request_id: z.uuid().nullable(),
+  record_type: z.string().nullable(),
   payload: z.record(z.string(), z.unknown()).nullable()
 });
 
@@ -40,6 +44,7 @@ export const REQUEST_LOGS_LIST_FIELDS = [
   'event_type',
   'success',
   'request_id',
+  'record_type',
   'payload'
 ] as const;
 

--- a/examples/brain-oauth/shared/schemas/oauth/OAuthAuthorizeSchema.ts
+++ b/examples/brain-oauth/shared/schemas/oauth/OAuthAuthorizeSchema.ts
@@ -71,14 +71,18 @@ export const OAuthClientCreateResponseSchema = z.object({
   created_at: z.string()
 });
 
-export type OAuthClientCreateResponse = z.infer<typeof OAuthClientCreateResponseSchema>;
+export type OAuthClientCreateResponse = z.infer<
+  typeof OAuthClientCreateResponseSchema
+>;
 
 export const OAuthClientSecretRotateResponseSchema = z.object({
   client_id: z.string(),
   client_secret: z.string()
 });
 
-export type OAuthClientSecretRotateResponse = z.infer<typeof OAuthClientSecretRotateResponseSchema>;
+export type OAuthClientSecretRotateResponse = z.infer<
+  typeof OAuthClientSecretRotateResponseSchema
+>;
 
 export const OAuthAuthorizeQuerySchema = z.object({
   response_type: z.literal('code'),

--- a/examples/brain-oauth/shared/schemas/oauth/OAuthClientSchema.ts
+++ b/examples/brain-oauth/shared/schemas/oauth/OAuthClientSchema.ts
@@ -7,7 +7,9 @@ export const OAuthUserCredentialsSchema = z.object({
   updated_at: z.string()
 });
 
-export type OAuthUserCredentialsRow = z.infer<typeof OAuthUserCredentialsSchema>;
+export type OAuthUserCredentialsRow = z.infer<
+  typeof OAuthUserCredentialsSchema
+>;
 
 export const OAuthRefreshTokenSchema = z.object({
   id: z.number(),

--- a/examples/brain-oauth/shared/supabase/admin.ts
+++ b/examples/brain-oauth/shared/supabase/admin.ts
@@ -8,7 +8,9 @@ import { SUPABASE_URL } from './conts';
 export function createAdminClient() {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!serviceKey) {
-    throw new Error('SUPABASE_SERVICE_ROLE_KEY is required for OAuth operations');
+    throw new Error(
+      'SUPABASE_SERVICE_ROLE_KEY is required for OAuth operations'
+    );
   }
   return createSupabaseClient(SUPABASE_URL!, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false }

--- a/examples/brain-oauth/shared/validators/OAuthAuthorizeValidator.ts
+++ b/examples/brain-oauth/shared/validators/OAuthAuthorizeValidator.ts
@@ -17,6 +17,9 @@ import type {
 export class OAuthAuthorizeQueryValidator
   implements ValidatorInterface<OAuthAuthorizeQuery>
 {
+  /**
+   * @override
+   */
   public validate(data: unknown): ValidationResult<OAuthAuthorizeQuery> {
     const result = OAuthAuthorizeQuerySchema.safeParse(data);
     if (!result.success) {
@@ -30,6 +33,9 @@ export class OAuthAuthorizeQueryValidator
     return { success: true, data: result.data };
   }
 
+  /**
+   * @override
+   */
   public getThrow(input: unknown): OAuthAuthorizeQuery {
     return OAuthAuthorizeQuerySchema.parse(input);
   }
@@ -39,6 +45,9 @@ export class OAuthAuthorizeQueryValidator
 export class OAuthConsentBodyValidator
   implements ValidatorInterface<OAuthConsentBody>
 {
+  /**
+   * @override
+   */
   public validate(data: unknown): ValidationResult<OAuthConsentBody> {
     const result = OAuthConsentBodySchema.safeParse(data);
     if (!result.success) {
@@ -52,6 +61,9 @@ export class OAuthConsentBodyValidator
     return { success: true, data: result.data };
   }
 
+  /**
+   * @override
+   */
   public getThrow(input: unknown): OAuthConsentBody {
     return OAuthConsentBodySchema.parse(input);
   }

--- a/examples/brain-oauth/shared/validators/SearchParamsValidator.ts
+++ b/examples/brain-oauth/shared/validators/SearchParamsValidator.ts
@@ -37,7 +37,9 @@ function parseOrder(raw: string | null): 'asc' | 'desc' {
   return v === 'asc' ? 'asc' : 'desc';
 }
 
-export class SearchParamsValidator implements ValidatorInterface<ResourceSearchParams> {
+export class SearchParamsValidator
+  implements ValidatorInterface<ResourceSearchParams>
+{
   protected parseFromSearchParams(
     searchParams: URLSearchParams
   ): ResourceSearchParams {

--- a/examples/brain-oauth/src/app/[locale]/auth/login/page.tsx
+++ b/examples/brain-oauth/src/app/[locale]/auth/login/page.tsx
@@ -81,7 +81,9 @@ export default async function LoginPage(props: PageParamsProps) {
           </h2>
           <p className="text-secondary-text mb-8">{tt.subtitle}</p>
 
-          <Suspense fallback={<p className="text-secondary-text">{tt.subtitle}</p>}>
+          <Suspense
+            fallback={<p className="text-secondary-text">{tt.subtitle}</p>}
+          >
             <LoginForm tt={tt} />
           </Suspense>
         </div>

--- a/examples/brain-oauth/src/app/[locale]/oauth/authorize/page.tsx
+++ b/examples/brain-oauth/src/app/[locale]/oauth/authorize/page.tsx
@@ -35,7 +35,9 @@ type OAuthAuthorizePageProps = PageParamsProps & {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default async function OAuthAuthorizePage(props: OAuthAuthorizePageProps) {
+export default async function OAuthAuthorizePage(
+  props: OAuthAuthorizePageProps
+) {
   const params = await props.params!;
   const pageParams = new AppPageRouteParams(params);
   const tt = await pageParams.getI18nInterface(

--- a/examples/brain-oauth/src/app/[locale]/oauth/playground/page.tsx
+++ b/examples/brain-oauth/src/app/[locale]/oauth/playground/page.tsx
@@ -28,7 +28,9 @@ export async function generateMetadata({
 
 type OAuthPlaygroundPageProps = PageParamsProps;
 
-export default async function OAuthPlaygroundPage(props: OAuthPlaygroundPageProps) {
+export default async function OAuthPlaygroundPage(
+  props: OAuthPlaygroundPageProps
+) {
   const params = await props.params!;
   const pageParams = new AppPageRouteParams(params);
   const tt = await pageParams.getI18nInterface(

--- a/examples/brain-oauth/src/app/api/brain/verify/route.ts
+++ b/examples/brain-oauth/src/app/api/brain/verify/route.ts
@@ -1,7 +1,7 @@
+import { NextResponse, type NextRequest } from 'next/server';
 import { API_BRAIN_VERIFY } from '@config/apiRoutes';
 import { BrainAuthController } from '@server/controllers/BrainAuthController';
 import { NextApiServer } from '@server/NextApiServer';
-import { NextResponse, type NextRequest } from 'next/server';
 
 /**
  * Brain email/password login for OAuth middleware session.

--- a/examples/brain-oauth/src/app/api/clients/[clientId]/rotate-secret/route.ts
+++ b/examples/brain-oauth/src/app/api/clients/[clientId]/rotate-secret/route.ts
@@ -1,8 +1,7 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { OAuthClientsController } from '@server/controllers/OAuthClientsController';
 import { NextApiServer } from '@server/NextApiServer';
 import { ServerAuthPlugin } from '@server/plugins/ServerAuthPlugin';
-import { OAuthClientsController } from '@server/controllers/OAuthClientsController';
+import type { NextRequest } from 'next/server';
 
 /**
  * @swagger

--- a/examples/brain-oauth/src/app/api/clients/[clientId]/route.ts
+++ b/examples/brain-oauth/src/app/api/clients/[clientId]/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { OAuthClientUpdateSchema } from '@schemas/oauth/OAuthAuthorizeSchema';
+import { OAuthClientsController } from '@server/controllers/OAuthClientsController';
 import { NextApiServer } from '@server/NextApiServer';
 import { ServerAuthPlugin } from '@server/plugins/ServerAuthPlugin';
-import { OAuthClientsController } from '@server/controllers/OAuthClientsController';
-import { OAuthClientUpdateSchema } from '@schemas/oauth/OAuthAuthorizeSchema';
+import type { NextRequest } from 'next/server';
 
 type ClientIdRouteContext = {
   params: Promise<{ clientId: string }>;

--- a/examples/brain-oauth/src/app/api/clients/route.ts
+++ b/examples/brain-oauth/src/app/api/clients/route.ts
@@ -1,12 +1,8 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { OAuthClientCreateSchema } from '@schemas/oauth/OAuthAuthorizeSchema';
+import { OAuthClientsController } from '@server/controllers/OAuthClientsController';
 import { NextApiServer } from '@server/NextApiServer';
 import { ServerAuthPlugin } from '@server/plugins/ServerAuthPlugin';
-import { OAuthClientsController } from '@server/controllers/OAuthClientsController';
-import { 
-  OAuthClientCreateSchema,
-  OAuthClientUpdateSchema
-} from '@schemas/oauth/OAuthAuthorizeSchema';
+import type { NextRequest } from 'next/server';
 
 /**
  * @swagger

--- a/examples/brain-oauth/src/app/api/oauth/consent/route.ts
+++ b/examples/brain-oauth/src/app/api/oauth/consent/route.ts
@@ -1,6 +1,6 @@
+import { NextResponse, type NextRequest } from 'next/server';
 import { OAuthConsentController } from '@server/controllers/OAuthConsentController';
 import { NextApiServer } from '@server/NextApiServer';
-import { NextResponse, type NextRequest } from 'next/server';
 
 /**
  * OAuth consent submission: allow or deny authorization for a registered client.

--- a/examples/brain-oauth/src/app/api/oauth/playground/validate/route.ts
+++ b/examples/brain-oauth/src/app/api/oauth/playground/validate/route.ts
@@ -1,5 +1,5 @@
-import { OAuthAuthorizeService } from '@server/services/OAuthAuthorizeService';
 import { NextApiServer } from '@server/NextApiServer';
+import { OAuthAuthorizeService } from '@server/services/OAuthAuthorizeService';
 import type { NextRequest } from 'next/server';
 
 /**
@@ -8,21 +8,22 @@ import type { NextRequest } from 'next/server';
 export async function GET(req: NextRequest) {
   const rawQuery = Object.fromEntries(req.nextUrl.searchParams.entries());
 
-  return await new NextApiServer('/api/oauth/playground/validate', req).runWithJson(
-    async ({ parameters: { IOC } }) => {
-      const resolved = await IOC(OAuthAuthorizeService).resolveAuthorizePage(
-        rawQuery
-      );
-      if (!resolved.ok) {
-        return {
-          valid: false as const,
-          error: resolved.error
-        };
-      }
+  return await new NextApiServer(
+    '/api/oauth/playground/validate',
+    req
+  ).runWithJson(async ({ parameters: { IOC } }) => {
+    const resolved = await IOC(OAuthAuthorizeService).resolveAuthorizePage(
+      rawQuery
+    );
+    if (!resolved.ok) {
       return {
-        valid: true as const,
-        data: resolved.data
+        valid: false as const,
+        error: resolved.error
       };
     }
-  );
+    return {
+      valid: true as const,
+      data: resolved.data
+    };
+  });
 }

--- a/examples/brain-oauth/src/app/oauth/token/route.ts
+++ b/examples/brain-oauth/src/app/oauth/token/route.ts
@@ -1,10 +1,10 @@
 import { BootstrapServer } from '@server/BootstrapServer';
 import { OAuthTokenController } from '@server/controllers/OAuthTokenController';
+import { logRequestEvent } from '@server/utils/logRequestEvent';
 import {
   OAuthTokenError,
   oauthTokenErrorResponse
 } from '@server/utils/oauthTokenError';
-import { logRequestEvent } from '@server/utils/logRequestEvent';
 import { parseOAuthTokenRequest } from '@server/utils/parseOAuthTokenRequest';
 import type { NextRequest } from 'next/server';
 
@@ -49,7 +49,11 @@ export async function POST(req: NextRequest) {
       req,
       started,
       oauthTokenErrorResponse(
-        new OAuthTokenError('invalid_request', 400, 'Unable to parse request body')
+        new OAuthTokenError(
+          'invalid_request',
+          400,
+          'Unable to parse request body'
+        )
       ),
       false
     );

--- a/examples/brain-oauth/src/impls/ClientIOCRegister.ts
+++ b/examples/brain-oauth/src/impls/ClientIOCRegister.ts
@@ -1,18 +1,18 @@
 import { CookieStorage } from '@qlover/corekit-bridge';
 import { Base64Serializer, StorageExecutor } from '@qlover/fe-corekit';
-import { I18nService } from '@/impls/I18nService';
-import { RouterService } from '@/impls/RouterService';
 import { BrainAuthGateway } from '@/impls/BrainAuthGateway';
+import { I18nService } from '@/impls/I18nService';
 import { OAuthConsentGateway } from '@/impls/OAuthConsentGateway';
+import { RouterService } from '@/impls/RouterService';
 import { UserService } from '@/impls/UserService';
 import { ZustandCounterService } from '@/impls/ZustandCounterService';
 import { StringEncryptor } from '@shared/StringEncryptor';
 import { cookiesConfig } from '@config/cookies';
 import { IOCIdentifier as I } from '@config/ioc-identifiter';
 import { AppApiRegister } from './appApi/AppApiRegister';
+import { OAuthClientsApi } from './appApi/OAuthClientsApi';
 import { dialogHandler, logger, JSON, appConfig } from './globals';
 import { LocalStorage } from './LocalStorage';
-import { OAuthClientsApi } from './appApi/OAuthClientsApi';
 import type {
   IOCContainerInterface,
   IOCRegisterInterface

--- a/examples/brain-oauth/src/impls/DialogErrorPlugin.ts
+++ b/examples/brain-oauth/src/impls/DialogErrorPlugin.ts
@@ -16,9 +16,10 @@ export type DialogErrorConfig = {
   disabledDialogError?: boolean;
 };
 @injectable()
-export class DialogErrorPlugin implements LifecyclePluginInterface<
-  ExecutorContextInterface<DialogErrorConfig>
-> {
+export class DialogErrorPlugin
+  implements
+    LifecyclePluginInterface<ExecutorContextInterface<DialogErrorConfig>>
+{
   public readonly pluginName = 'DialogErrorPlugin';
 
   constructor(

--- a/examples/brain-oauth/src/impls/DialogHandler.ts
+++ b/examples/brain-oauth/src/impls/DialogHandler.ts
@@ -11,7 +11,8 @@ import type {
 import type { ModalFuncProps } from 'antd';
 
 export interface DialogHandlerOptions
-  extends NotificationOptions, ModalFuncProps {
+  extends NotificationOptions,
+    ModalFuncProps {
   content: string;
 }
 

--- a/examples/brain-oauth/src/impls/RequestEncryptPlugin.ts
+++ b/examples/brain-oauth/src/impls/RequestEncryptPlugin.ts
@@ -6,9 +6,8 @@ import type {
   EncryptorInterface
 } from '@qlover/fe-corekit';
 
-export interface RequestEncryptPluginProps<
-  Request = unknown
-> extends RequestAdapterConfig<Request> {
+export interface RequestEncryptPluginProps<Request = unknown>
+  extends RequestAdapterConfig<Request> {
   /**
    * 加密密码在 HTTP 请求中
    *
@@ -19,9 +18,12 @@ export interface RequestEncryptPluginProps<
   encryptProps?: string[] | string;
 }
 
-export class RequestEncryptPlugin implements LifecyclePluginInterface<
-  ExecutorContextInterface<RequestEncryptPluginProps>
-> {
+export class RequestEncryptPlugin
+  implements
+    LifecyclePluginInterface<
+      ExecutorContextInterface<RequestEncryptPluginProps>
+    >
+{
   public readonly pluginName = 'RequestEncryptPlugin';
 
   constructor(protected encryptor: EncryptorInterface<string, string>) {}

--- a/examples/brain-oauth/src/impls/appApi/AppApiPlugin.ts
+++ b/examples/brain-oauth/src/impls/appApi/AppApiPlugin.ts
@@ -11,9 +11,9 @@ export type AppApiPluginOptions = {
   disabledLoggerError?: boolean;
 };
 
-export class AppApiPlugin implements LifecyclePluginInterface<
-  ExecutorContextInterface<AppApiConfig>
-> {
+export class AppApiPlugin
+  implements LifecyclePluginInterface<ExecutorContextInterface<AppApiConfig>>
+{
   public readonly pluginName = 'AppApiPlugin';
 
   constructor(protected logger: LoggerInterface) {}

--- a/examples/brain-oauth/src/impls/appApi/AppApiRegister.ts
+++ b/examples/brain-oauth/src/impls/appApi/AppApiRegister.ts
@@ -17,7 +17,9 @@ import type {
 } from '@qlover/corekit-bridge';
 import type { SerializerIneterface } from '@qlover/fe-corekit';
 
-export class AppApiRegister implements IOCRegisterInterface<IOCContainerInterface> {
+export class AppApiRegister
+  implements IOCRegisterInterface<IOCContainerInterface>
+{
   constructor(protected serializer: SerializerIneterface) {}
 
   /**

--- a/examples/brain-oauth/src/impls/appApi/AppApiRequester.ts
+++ b/examples/brain-oauth/src/impls/appApi/AppApiRequester.ts
@@ -26,7 +26,8 @@ export type AppApiConfig<Request = unknown> = RequestAdapterConfig<Request> &
   AppApiPluginOptions &
   AborterConfig;
 
-export interface AppApiRequesterContext extends ExecutorContextInterface<AppApiConfig> {}
+export interface AppApiRequesterContext
+  extends ExecutorContextInterface<AppApiConfig> {}
 
 /**
  * UserApiResponse
@@ -45,13 +46,11 @@ export type AppApiResponse<
 /**
  * UserApi common transaction
  */
-export interface AppApiTransaction<
-  Request = unknown,
-  Response = unknown
-> extends RequestTransactionInterface<
-  AppApiConfig<Request>,
-  AppApiResponse<Request, Response>
-> {
+export interface AppApiTransaction<Request = unknown, Response = unknown>
+  extends RequestTransactionInterface<
+    AppApiConfig<Request>,
+    AppApiResponse<Request, Response>
+  > {
   data: AppApiConfig<Request>['data'];
 }
 

--- a/examples/brain-oauth/src/impls/appApi/OAuthClientsApi.ts
+++ b/examples/brain-oauth/src/impls/appApi/OAuthClientsApi.ts
@@ -1,5 +1,4 @@
 import { inject } from '@shared/container';
-import { AppApiRequester } from './AppApiRequester';
 import type {
   OAuthClientListItem,
   OAuthClientDetail,
@@ -9,6 +8,7 @@ import type {
   OAuthClientSecretRotateResponse
 } from '@schemas/oauth/OAuthAuthorizeSchema';
 import type { AppApiSuccessInterface } from '@interfaces/AppApiInterface';
+import { AppApiRequester } from './AppApiRequester';
 
 export class OAuthClientsApi {
   constructor(
@@ -20,7 +20,9 @@ export class OAuthClientsApi {
    */
   public async list(): Promise<OAuthClientListItem[]> {
     const response = await this.appApiRequester.get('/api/clients');
-    const envelope = response.data as AppApiSuccessInterface<OAuthClientListItem[]>;
+    const envelope = response.data as AppApiSuccessInterface<
+      OAuthClientListItem[]
+    >;
     return envelope.data ?? [];
   }
 
@@ -36,9 +38,12 @@ export class OAuthClientsApi {
   /**
    * Create a new OAuth client
    */
-  public async create(input: OAuthClientCreate): Promise<OAuthClientCreateResponse> {
+  public async create(
+    input: OAuthClientCreate
+  ): Promise<OAuthClientCreateResponse> {
     const response = await this.appApiRequester.post('/api/clients', input);
-    const envelope = response.data as AppApiSuccessInterface<OAuthClientCreateResponse>;
+    const envelope =
+      response.data as AppApiSuccessInterface<OAuthClientCreateResponse>;
     return envelope.data!;
   }
 
@@ -49,7 +54,10 @@ export class OAuthClientsApi {
     clientId: string,
     input: OAuthClientUpdate
   ): Promise<OAuthClientDetail> {
-    const response = await this.appApiRequester.put(`/api/clients/${clientId}`, input);
+    const response = await this.appApiRequester.put(
+      `/api/clients/${clientId}`,
+      input
+    );
     const envelope = response.data as AppApiSuccessInterface<OAuthClientDetail>;
     return envelope.data!;
   }
@@ -64,9 +72,14 @@ export class OAuthClientsApi {
   /**
    * Rotate client secret
    */
-  public async rotateSecret(clientId: string): Promise<OAuthClientSecretRotateResponse> {
-    const response = await this.appApiRequester.post(`/api/clients/${clientId}/rotate-secret`);
-    const envelope = response.data as AppApiSuccessInterface<OAuthClientSecretRotateResponse>;
+  public async rotateSecret(
+    clientId: string
+  ): Promise<OAuthClientSecretRotateResponse> {
+    const response = await this.appApiRequester.post(
+      `/api/clients/${clientId}/rotate-secret`
+    );
+    const envelope =
+      response.data as AppApiSuccessInterface<OAuthClientSecretRotateResponse>;
     return envelope.data!;
   }
 }

--- a/examples/brain-oauth/src/impls/bootstraps/BootstrapClient.ts
+++ b/examples/brain-oauth/src/impls/bootstraps/BootstrapClient.ts
@@ -15,7 +15,9 @@ import type {
   BootstrapInterface
 } from '@qlover/corekit-bridge/bootstrap';
 
-export class BootstrapClient implements BootstrapInterface<BootstrapExecutorPlugin> {
+export class BootstrapClient
+  implements BootstrapInterface<BootstrapExecutorPlugin>
+{
   constructor(
     protected IOC: IOCFunctionInterface<IOCIdentifierMap, IOCContainerInterface>
   ) {}

--- a/examples/brain-oauth/src/pages/[locale]/developer/apps/CopyableCredential.tsx
+++ b/examples/brain-oauth/src/pages/[locale]/developer/apps/CopyableCredential.tsx
@@ -12,7 +12,10 @@ export function CopyableCredential(props: {
   const { value, onCopy, className } = props;
 
   return (
-    <div className={clsx('flex items-center gap-2 min-w-0', className)}>
+    <div
+      data-testid="CopyableCredential"
+      className={clsx('flex items-center gap-2 min-w-0', className)}
+    >
       <code className="flex-1 min-w-0 bg-secondary text-primary-text px-2 py-2 rounded-lg text-sm break-all font-mono border border-primary-border/40">
         {value}
       </code>

--- a/examples/brain-oauth/src/pages/[locale]/developer/apps/DeveloperAppsPage.tsx
+++ b/examples/brain-oauth/src/pages/[locale]/developer/apps/DeveloperAppsPage.tsx
@@ -9,16 +9,22 @@ import {
   LoadingOutlined,
   PlusOutlined
 } from '@ant-design/icons';
+import { message } from 'antd';
+import { clsx } from 'clsx';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent
+} from 'react';
 import { Link } from '@/i18n/routing';
-import { ROUTE_OAUTH_PLAYGROUND } from '@config/route';
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
-import { useI18nMapping } from '@/uikit/hook/useI18nMapping';
-import { developerAppsI18n } from '@config/i18n-mapping/developerAppsI18n';
 import {
   DeveloperConfirmDialog,
   type DeveloperConfirmOptions
 } from '@/uikit/components-app/developer/DeveloperConfirmDialog';
 import { DeveloperOverlayModal } from '@/uikit/components-app/developer/DeveloperOverlayModal';
+import { useI18nMapping } from '@/uikit/hook/useI18nMapping';
 import {
   oauthCardClass,
   oauthDangerButtonClass,
@@ -28,6 +34,8 @@ import {
   oauthSecondaryButtonClass,
   oauthWarningButtonClass
 } from '@/uikit/styles/oauthUiStyles';
+import { developerAppsI18n } from '@config/i18n-mapping/developerAppsI18n';
+import { ROUTE_OAUTH_PLAYGROUND } from '@config/route';
 import type {
   OAuthClientListItem,
   OAuthClientCreate,
@@ -36,18 +44,16 @@ import type {
   OAuthClientSecretRotateResponse,
   OAuthClientUpdate
 } from '@schemas/oauth/OAuthAuthorizeSchema';
-import { readAppApiJson } from './readAppApiJson';
-import { clsx } from 'clsx';
-import { message } from 'antd';
-import {
-  OAuthClientCredentialsModal,
-  type OAuthCredentials
-} from './OAuthClientCredentialsModal';
 import {
   OAuthClientAppForm,
   emptyOAuthClientFormValues,
   type OAuthClientFormValues
 } from './OAuthClientAppForm';
+import {
+  OAuthClientCredentialsModal,
+  type OAuthCredentials
+} from './OAuthClientCredentialsModal';
+import { readAppApiJson } from './readAppApiJson';
 
 function parseRedirectUris(raw: string): string[] {
   return raw
@@ -72,7 +78,9 @@ export function DeveloperAppsPageComponent({
   const [loading, setLoading] = useState(true);
   const [createModalVisible, setCreateModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
-  const [editingApp, setEditingApp] = useState<OAuthClientListItem | null>(null);
+  const [editingApp, setEditingApp] = useState<OAuthClientListItem | null>(
+    null
+  );
   const [credentials, setCredentials] = useState<OAuthCredentials | null>(null);
   const [credentialsModalVisible, setCredentialsModalVisible] = useState(false);
   const [confirmOptions, setConfirmOptions] =
@@ -101,8 +109,7 @@ export function DeveloperAppsPageComponent({
       redirectUrisHint:
         tt.redirectUrisHint ||
         'Multiple callback URLs supported, one per line. Must use HTTPS (http://localhost allowed for local development).',
-      clientUriLabel:
-        tt.clientUriLabel || 'Application Homepage URL (Optional)'
+      clientUriLabel: tt.clientUriLabel || 'Application Homepage URL (Optional)'
     }),
     [tt]
   );
@@ -141,7 +148,9 @@ export function DeveloperAppsPageComponent({
       setApps(Array.isArray(data) ? data : []);
     } catch (error) {
       console.error('Load apps error:', error);
-      message.error(tt.toastError || 'Operation failed, please try again later');
+      message.error(
+        tt.toastError || 'Operation failed, please try again later'
+      );
     } finally {
       setLoading(false);
     }
@@ -161,7 +170,9 @@ export function DeveloperAppsPageComponent({
       await copyText(clientId);
       message.success(tt.copyClientIdSuccess || 'Client ID copied');
     } catch {
-      message.error(tt.toastError || 'Operation failed, please try again later');
+      message.error(
+        tt.toastError || 'Operation failed, please try again later'
+      );
     }
   };
 
@@ -176,7 +187,9 @@ export function DeveloperAppsPageComponent({
         message.success(tt.copySecretSuccess || 'Client Secret copied');
       }
     } catch {
-      message.error(tt.toastError || 'Operation failed, please try again later');
+      message.error(
+        tt.toastError || 'Operation failed, please try again later'
+      );
     }
   };
 
@@ -234,7 +247,9 @@ export function DeveloperAppsPageComponent({
       });
     } catch (error) {
       console.error('Create app error:', error);
-      message.error(tt.toastError || 'Operation failed, please try again later');
+      message.error(
+        tt.toastError || 'Operation failed, please try again later'
+      );
     }
   };
 
@@ -291,10 +306,14 @@ export function DeveloperAppsPageComponent({
       setEditingApp(null);
       resetEditForm();
 
-      message.success(tt.toastUpdateSuccess || 'Application updated successfully');
+      message.success(
+        tt.toastUpdateSuccess || 'Application updated successfully'
+      );
     } catch (error) {
       console.error('Update app error:', error);
-      message.error(tt.toastError || 'Operation failed, please try again later');
+      message.error(
+        tt.toastError || 'Operation failed, please try again later'
+      );
     }
   };
 
@@ -318,16 +337,17 @@ export function DeveloperAppsPageComponent({
             throw new Error('Failed to rotate secret');
           }
 
-          const data = await readAppApiJson<OAuthClientSecretRotateResponse>(
-            response
-          );
+          const data =
+            await readAppApiJson<OAuthClientSecretRotateResponse>(response);
           showCredentialsModal({
             clientId,
             clientSecret: data.client_secret
           });
         } catch (error) {
           console.error('Rotate secret error:', error);
-          message.error(tt.toastError || 'Operation failed, please try again later');
+          message.error(
+            tt.toastError || 'Operation failed, please try again later'
+          );
           throw error;
         }
       }
@@ -361,7 +381,9 @@ export function DeveloperAppsPageComponent({
           message.success(tt.toastDeleteSuccess || 'Application deleted');
         } catch (error) {
           console.error('Delete app error:', error);
-          message.error(tt.toastError || 'Operation failed, please try again later');
+          message.error(
+            tt.toastError || 'Operation failed, please try again later'
+          );
           throw error;
         }
       }
@@ -400,7 +422,10 @@ export function DeveloperAppsPageComponent({
                   </h1>
                 </div>
                 <div className="flex flex-wrap items-center gap-2 shrink-0">
-                  <Link href={ROUTE_OAUTH_PLAYGROUND} className={oauthSecondaryButtonClass}>
+                  <Link
+                    href={ROUTE_OAUTH_PLAYGROUND}
+                    className={oauthSecondaryButtonClass}
+                  >
                     <ExperimentOutlined />
                     {tt.playgroundLink || 'OAuth playground'}
                   </Link>
@@ -440,6 +465,7 @@ export function DeveloperAppsPageComponent({
                 <div className="space-y-4">
                   {apps.map((app) => (
                     <article
+                      data-testid="DeveloperAppsPageComponent"
                       key={app.client_id}
                       className={clsx(
                         oauthElevatedPanelClass,
@@ -468,9 +494,13 @@ export function DeveloperAppsPageComponent({
                             </code>
                             <button
                               type="button"
-                              onClick={() => void handleCopyClientId(app.client_id)}
+                              onClick={() =>
+                                void handleCopyClientId(app.client_id)
+                              }
                               className={oauthGhostActionClass}
-                              aria-label={tt.copyClientIdSuccess || 'Copy Client ID'}
+                              aria-label={
+                                tt.copyClientIdSuccess || 'Copy Client ID'
+                              }
                             >
                               <CopyOutlined />
                             </button>
@@ -589,7 +619,9 @@ export function DeveloperAppsPageComponent({
             setCreateValues((prev) => ({ ...prev, ...patch }));
             setCreateFieldErrors((prev) => {
               const next = { ...prev };
-              for (const key of Object.keys(patch) as (keyof OAuthClientFormValues)[]) {
+              for (const key of Object.keys(
+                patch
+              ) as (keyof OAuthClientFormValues)[]) {
                 delete next[key];
               }
               return next;
@@ -617,7 +649,9 @@ export function DeveloperAppsPageComponent({
                   <button
                     type="button"
                     className={oauthWarningButtonClass}
-                    onClick={() => void handleRotateSecret(editingApp.client_id)}
+                    onClick={() =>
+                      void handleRotateSecret(editingApp.client_id)
+                    }
                   >
                     <KeyOutlined />
                     {tt.rotateSecretButton || 'Rotate Secret'}
@@ -671,7 +705,9 @@ export function DeveloperAppsPageComponent({
             setEditValues((prev) => ({ ...prev, ...patch }));
             setEditFieldErrors((prev) => {
               const next = { ...prev };
-              for (const key of Object.keys(patch) as (keyof OAuthClientFormValues)[]) {
+              for (const key of Object.keys(
+                patch
+              ) as (keyof OAuthClientFormValues)[]) {
                 delete next[key];
               }
               return next;

--- a/examples/brain-oauth/src/pages/[locale]/developer/apps/OAuthClientAppForm.tsx
+++ b/examples/brain-oauth/src/pages/[locale]/developer/apps/OAuthClientAppForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import type { FormEvent, ReactNode } from 'react';
 import { oauthInputClass, oauthLabelClass } from '@/uikit/styles/oauthUiStyles';
+import type { FormEvent, ReactNode } from 'react';
 
 export type OAuthClientFormValues = {
   client_name: string;
@@ -35,11 +35,24 @@ export function OAuthClientAppForm(props: {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   footer?: ReactNode | null;
 }) {
-  const { formId, values, fieldErrors = {}, labels, onChange, onSubmit, footer } =
-    props;
+  const {
+    formId,
+    values,
+    fieldErrors = {},
+    labels,
+    onChange,
+    onSubmit,
+    footer
+  } = props;
 
   return (
-    <form id={formId} onSubmit={onSubmit} className="space-y-4" noValidate>
+    <form
+      data-testid="OAuthClientAppForm"
+      id={formId}
+      onSubmit={onSubmit}
+      className="space-y-4"
+      noValidate
+    >
       <div>
         <label htmlFor={`${formId}-client_name`} className={oauthLabelClass}>
           {labels.appNameLabel} <span className="text-red-500">*</span>

--- a/examples/brain-oauth/src/pages/[locale]/developer/apps/OAuthClientCredentialsModal.tsx
+++ b/examples/brain-oauth/src/pages/[locale]/developer/apps/OAuthClientCredentialsModal.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { CopyableCredential } from './CopyableCredential';
 import { DeveloperOverlayModal } from '@/uikit/components-app/developer/DeveloperOverlayModal';
-import { oauthLabelClass, oauthPrimaryButtonClass } from '@/uikit/styles/oauthUiStyles';
+import {
+  oauthLabelClass,
+  oauthPrimaryButtonClass
+} from '@/uikit/styles/oauthUiStyles';
+import { CopyableCredential } from './CopyableCredential';
 
 export interface OAuthCredentials {
   clientId: string;
@@ -43,7 +46,11 @@ export function OAuthClientCredentialsModal(props: {
       closeOnBackdrop={false}
       footer={
         <div className="flex justify-end">
-          <button type="button" className={oauthPrimaryButtonClass} onClick={onClose}>
+          <button
+            type="button"
+            className={oauthPrimaryButtonClass}
+            onClick={onClose}
+          >
             {confirmLabel}
           </button>
         </div>

--- a/examples/brain-oauth/src/pages/[locale]/developer/apps/index.tsx
+++ b/examples/brain-oauth/src/pages/[locale]/developer/apps/index.tsx
@@ -8,15 +8,14 @@ import { useI18nMapping } from '@/uikit/hook/useI18nMapping';
 import { i18nConfig } from '@config/i18n';
 import { COMMON_ADMIN_TITLE } from '@config/i18n-identifier/common/common';
 import { developerAppsI18n } from '@config/i18n-mapping/developerAppsI18n';
+import type { OAuthClientListItem } from '@schemas/oauth/OAuthAuthorizeSchema';
 import type { PagesRouteParamsType } from '@server/render/PagesRouteParams';
 import { PagesRouteParams } from '@server/render/PagesRouteParams';
 import type { GetStaticPropsContext } from 'next';
-import type { OAuthClientListItem } from '@schemas/oauth/OAuthAuthorizeSchema';
 
 const DeveloperAppsPageComponent = dynamic(
-  () => import('./DeveloperAppsPage').then(
-    (mod) => mod.DeveloperAppsPageComponent
-  ),
+  () =>
+    import('./DeveloperAppsPage').then((mod) => mod.DeveloperAppsPageComponent),
   { ssr: false }
 );
 

--- a/examples/brain-oauth/src/proxy.ts
+++ b/examples/brain-oauth/src/proxy.ts
@@ -1,9 +1,9 @@
 // Import your routing configuration which contains all locales, defaultLocale, and pathnames
-import { isOAuthMachinePath } from '@config/route';
-import { updateSession } from '@shared/supabase/proxy';
-import { routing } from './i18n/routing';
 import { NextResponse, type NextRequest } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
+import { updateSession } from '@shared/supabase/proxy';
+import { isOAuthMachinePath } from '@config/route';
+import { routing } from './i18n/routing';
 
 export default async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;

--- a/examples/brain-oauth/src/uikit/components-app/AppRoutePageApp.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/AppRoutePageApp.tsx
@@ -50,7 +50,10 @@ export function AppRoutePageApp({
         <>
           {showDeveloperButton && developerTitle && (
             <Suspense>
-              <DeveloperButton developerTitle={developerTitle} locale={locale} />
+              <DeveloperButton
+                developerTitle={developerTitle}
+                locale={locale}
+              />
             </Suspense>
           )}
           {showAdminButton && (

--- a/examples/brain-oauth/src/uikit/components-app/AppRoutePagePages.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/AppRoutePagePages.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useLocale } from 'next-intl';
 import { Suspense } from 'react';
 import { AdminButton } from './AdminButton';
 import { DeveloperButton } from './DeveloperButton';
@@ -7,7 +8,6 @@ import { LanguageSwitcherPages } from './LanguageSwitcherPages';
 import { LogoutButton } from './LogoutButton';
 import { RoutePageLayout } from './RoutePageLayout';
 import type { AppRoutePageProps } from './AppRoutePage.types';
-import { useLocale } from 'next-intl';
 
 /**
  * Pages Router variant — no imports from `next-intl/navigation` or `@/i18n/routing`.
@@ -45,7 +45,10 @@ export function AppRoutePagePages({
         <>
           {showDeveloperButton && developerTitle && (
             <Suspense>
-              <DeveloperButton developerTitle={developerTitle} locale={locale} />
+              <DeveloperButton
+                developerTitle={developerTitle}
+                locale={locale}
+              />
             </Suspense>
           )}
           {showAdminButton && (

--- a/examples/brain-oauth/src/uikit/components-app/AuthButton.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/AuthButton.tsx
@@ -17,6 +17,7 @@ export function AuthButton(props: {
   if (loading) {
     return (
       <div
+        data-testid="AuthButton"
         className="h-8 w-10 sm:h-9 sm:w-16 animate-pulse rounded-lg bg-elevated border border-primary-border/60"
         aria-hidden
       />

--- a/examples/brain-oauth/src/uikit/components-app/AuthButtonUI.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/AuthButtonUI.tsx
@@ -7,8 +7,8 @@ import {
   COMMON_USER_AUTH_FAILED_GO_TO_LOGIN
 } from '@config/i18n-identifier/common/common';
 import { ROUTE_LOGIN, ROUTE_REGISTER } from '@config/route';
-import { LogoutButton } from './LogoutButton';
 import { headerActionButtonClassName } from './headerStyles';
+import { LogoutButton } from './LogoutButton';
 import { useWarnTranslations } from '../hook/useWarnTranslations';
 
 /**
@@ -51,10 +51,7 @@ export function AuthButtonUI(props: {
         className="flex items-center gap-2"
         data-auth={hasAuth}
       >
-        <LogoutButton
-          data-testid="logout-button"
-          showLabel={showLogoutLabel}
-        />
+        <LogoutButton data-testid="logout-button" showLabel={showLogoutLabel} />
       </div>
     );
   }

--- a/examples/brain-oauth/src/uikit/components-app/DeveloperButton.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/DeveloperButton.tsx
@@ -8,7 +8,10 @@ import { useUserAuth } from '../hook/useUserAuth';
  * Client component: Developer console button
  * Shows when user is authenticated
  */
-export function DeveloperButton(props: { developerTitle: string; locale?: string }) {
+export function DeveloperButton(props: {
+  developerTitle: string;
+  locale?: string;
+}) {
   const { developerTitle, locale } = props;
   const { success, loading } = useUserAuth();
 

--- a/examples/brain-oauth/src/uikit/components-app/LanguageSwitcher.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/LanguageSwitcher.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { TranslationOutlined } from '@ant-design/icons';
+import { useMountedClient } from '@brain-toolkit/react-kit';
 import { Dropdown } from 'antd';
 import { useLocale } from 'next-intl';
-import { useMountedClient } from '@brain-toolkit/react-kit';
 import { useCallback, useMemo, useTransition } from 'react';
 import { usePathname, useRouter } from '@/i18n/routing';
-import { headerActionButtonClassName } from './headerStyles';
 import { i18nConfig } from '@config/i18n';
 import type { LocaleType } from '@config/i18n';
+import { headerActionButtonClassName } from './headerStyles';
 import type { ItemType } from 'antd/es/menu/interface';
 
 export function LanguageSwitcher() {

--- a/examples/brain-oauth/src/uikit/components-app/LanguageSwitcherPages.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/LanguageSwitcherPages.tsx
@@ -2,14 +2,14 @@
 
 import { TranslationOutlined } from '@ant-design/icons';
 import { Dropdown } from 'antd';
-import { useLocale } from 'next-intl';
 import { useRouter } from 'next/router';
+import { useLocale } from 'next-intl';
 import { useCallback, useMemo, useState } from 'react';
 import { useLocaleRoutes } from '@config/common';
 import { i18nConfig } from '@config/i18n';
 import type { LocaleType } from '@config/i18n';
-import type { ItemType } from 'antd/es/menu/interface';
 import { headerActionButtonClassName } from './headerStyles';
+import type { ItemType } from 'antd/es/menu/interface';
 
 const localePrefixPattern = new RegExp(
   `^/(${i18nConfig.supportedLngs.join('|')})(?=/|$)`

--- a/examples/brain-oauth/src/uikit/components-app/LogoutButton.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/LogoutButton.tsx
@@ -4,12 +4,12 @@ import { LogoutOutlined } from '@ant-design/icons';
 import { Tooltip } from 'antd';
 import { clsx } from 'clsx';
 import { useCallback } from 'react';
-import { headerActionButtonClassName } from './headerStyles';
 import {
   COMMON_LOGOUT_DIALOG_CONTENT,
   COMMON_LOGOUT_DIALOG_TITLE
 } from '@config/i18n-identifier/common/common';
 import { I } from '@config/ioc-identifiter';
+import { headerActionButtonClassName } from './headerStyles';
 import { useI18nMapping } from '../hook/useI18nMapping';
 import { useIOC } from '../hook/useIOC';
 

--- a/examples/brain-oauth/src/uikit/components-app/RoutePageLayout.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/RoutePageLayout.tsx
@@ -2,10 +2,10 @@
 
 import { clsx } from 'clsx';
 import { useLocale } from 'next-intl';
-import type { HTMLAttributes, ReactNode } from 'react';
-import { LocaleLink } from '../components/LocaleLink';
 import { ThemeSwitcher } from './ThemeSwitcher';
+import { LocaleLink } from '../components/LocaleLink';
 import type { AppRoutePageTT } from './AppRoutePage.types';
+import type { HTMLAttributes, ReactNode } from 'react';
 
 export interface RoutePageLayoutProps extends HTMLAttributes<HTMLDivElement> {
   tt: AppRoutePageTT;

--- a/examples/brain-oauth/src/uikit/components-app/ThemeSwitcher.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/ThemeSwitcher.tsx
@@ -23,9 +23,9 @@ import {
 } from '@config/i18n-identifier/common/common';
 import { I } from '@config/ioc-identifiter';
 import { type SupportedTheme, themeConfig } from '@config/theme';
+import { headerActionButtonClassName } from './headerStyles';
 import { useIOC } from '../hook/useIOC';
 import { useWarnTranslations } from '../hook/useWarnTranslations';
-import { headerActionButtonClassName } from './headerStyles';
 import type { ItemType } from 'antd/es/menu/interface';
 
 const { supportedThemes, storageKey } = themeConfig;

--- a/examples/brain-oauth/src/uikit/components-app/developer/DeveloperConfirmDialog.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/developer/DeveloperConfirmDialog.tsx
@@ -47,7 +47,9 @@ export function DeveloperConfirmDialog({
   if (!options) return null;
 
   const okClass =
-    options.variant === 'danger' ? oauthDangerButtonClass : oauthPrimaryButtonClass;
+    options.variant === 'danger'
+      ? oauthDangerButtonClass
+      : oauthPrimaryButtonClass;
 
   return (
     <DeveloperOverlayModal

--- a/examples/brain-oauth/src/uikit/components-app/developer/DeveloperOverlayModal.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/developer/DeveloperOverlayModal.tsx
@@ -39,6 +39,7 @@ export function DeveloperOverlayModal(props: {
 
   return (
     <div
+      data-testid="DeveloperOverlayModal"
       className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-6"
       role="dialog"
       aria-modal="true"

--- a/examples/brain-oauth/src/uikit/components-app/home/HomeHeaderNav.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/home/HomeHeaderNav.tsx
@@ -62,7 +62,11 @@ export function HomeHeaderNav({ tt }: HomeHeaderNavProps) {
         aria-label={menuOpen ? 'Close menu' : 'Open menu'}
         onClick={() => setMenuOpen((open) => !open)}
       >
-        {menuOpen ? <CloseOutlined className="text-base" /> : <MenuOutlined className="text-base" />}
+        {menuOpen ? (
+          <CloseOutlined className="text-base" />
+        ) : (
+          <MenuOutlined className="text-base" />
+        )}
       </button>
 
       <div
@@ -70,7 +74,9 @@ export function HomeHeaderNav({ tt }: HomeHeaderNavProps) {
         data-testid="HomeHeaderNavMobilePanel"
         className={clsx(
           'md:hidden fixed left-0 right-0 top-16 z-40 border-b border-primary-border bg-primary/95 backdrop-blur-md shadow-sm',
-          menuOpen ? 'visible opacity-100' : 'invisible opacity-0 pointer-events-none'
+          menuOpen
+            ? 'visible opacity-100'
+            : 'invisible opacity-0 pointer-events-none'
         )}
       >
         <nav

--- a/examples/brain-oauth/src/uikit/components-app/home/HomeSections.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/home/HomeSections.tsx
@@ -11,10 +11,7 @@ import { clsx } from 'clsx';
 import { Link } from '@/i18n/routing';
 import { API_REFERENCE } from '@config/apiRoutes';
 import type { HomeI18nInterface } from '@config/i18n-mapping/HomeI18n';
-import {
-  ROUTE_DASHBOARD_APPS,
-  ROUTE_REGISTER
-} from '@config/route';
+import { ROUTE_DASHBOARD_APPS, ROUTE_REGISTER } from '@config/route';
 
 const primaryButtonClassName =
   'inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-brand text-on-brand font-medium hover:bg-brand-hover transition shadow-md';
@@ -33,10 +30,7 @@ export { HomeHeaderNav } from './HomeHeaderNav';
 
 export function HomeHero({ tt }: HomeSectionProps) {
   return (
-    <section
-      data-testid="HomeHero"
-      className="py-10 sm:py-16 md:py-24"
-    >
+    <section data-testid="HomeHero" className="py-10 sm:py-16 md:py-24">
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         <div className="inline-flex max-w-full items-center gap-2 bg-brand/10 text-brand px-3 py-1 rounded-full text-xs sm:text-sm mb-4 sm:mb-6">
           <CheckCircleOutlined className="shrink-0" />
@@ -89,7 +83,7 @@ export function HomeFeatures({ tt }: HomeSectionProps) {
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
           {features.map((feature) => (
-            <div key={feature.label}>
+            <div data-testid="HomeFeatures" key={feature.label}>
               <div className={featureIconWrapClassName}>{feature.icon}</div>
               <p className="font-medium text-primary-text">{feature.label}</p>
             </div>
@@ -102,10 +96,7 @@ export function HomeFeatures({ tt }: HomeSectionProps) {
 
 export function HomeApiSnippet() {
   return (
-    <section
-      data-testid="HomeApiSnippet"
-      className="bg-elevated py-8 sm:py-12"
-    >
+    <section data-testid="HomeApiSnippet" className="bg-elevated py-8 sm:py-12">
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="rounded-xl bg-primary shadow-sm border border-primary-border p-5">
           <p className="text-sm font-mono text-secondary-text break-all">
@@ -113,8 +104,8 @@ export function HomeApiSnippet() {
             /oauth/authorize?client_id=your_app&amp;redirect_uri=...
           </p>
           <p className="text-sm font-mono text-secondary-text mt-2 break-all">
-            <span className="text-brand">POST</span>{' '}
-            /oauth/token -d &quot;grant_type=authorization_code&amp;code=...&quot;
+            <span className="text-brand">POST</span> /oauth/token -d
+            &quot;grant_type=authorization_code&amp;code=...&quot;
           </p>
         </div>
       </div>

--- a/examples/brain-oauth/src/uikit/components-app/oauth/OAuthAuthorizeCard.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/oauth/OAuthAuthorizeCard.tsx
@@ -12,8 +12,8 @@ import {
 } from '@ant-design/icons';
 import { clsx } from 'clsx';
 import { useCallback, useMemo, useState } from 'react';
-import { useIOC } from '@/uikit/hook/useIOC';
 import { OAuthConsentGateway } from '@/impls/OAuthConsentGateway';
+import { useIOC } from '@/uikit/hook/useIOC';
 import type { OAuthAuthorizeI18nInterface } from '@config/i18n-mapping/OAuthAuthorizeI18n';
 import { resolveScopeLabel } from '@config/i18n-mapping/OAuthAuthorizeI18n';
 import type { OAuthAuthorizePageData } from '@server/services/OAuthAuthorizeService';
@@ -61,9 +61,7 @@ export function OAuthAuthorizeCard({
 
         window.location.assign(redirectUrl);
       } catch (err) {
-        setErrorMessage(
-          err instanceof Error ? err.message : tt.errorConsent
-        );
+        setErrorMessage(err instanceof Error ? err.message : tt.errorConsent);
         setLoading(false);
       }
     },
@@ -161,7 +159,11 @@ export function OAuthAuthorizeCard({
           </button>
           <div className="mt-2 space-y-2 pl-1">
             {scopeLabels.map(({ scope, label }) => (
-              <div key={scope} className="flex items-start gap-2">
+              <div
+                data-testid="OAuthAuthorizeCard"
+                key={scope}
+                className="flex items-start gap-2"
+              >
                 <CheckCircleOutlined className="text-green-500 text-sm mt-0.5 shrink-0" />
                 <span className="text-sm text-primary-text">{label}</span>
               </div>

--- a/examples/brain-oauth/src/uikit/components-app/oauth/OAuthPlayground.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/oauth/OAuthPlayground.tsx
@@ -10,27 +10,33 @@ import {
   ReloadOutlined
 } from '@ant-design/icons';
 import { clsx } from 'clsx';
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
-import { Link } from '@/i18n/routing';
 import { useLocale } from 'next-intl';
-import { usePageI18nMapping } from '@/uikit/context/PageI18nContext';
-import { useUserAuth } from '@/uikit/hook/useUserAuth';
-import { useIOC } from '@/uikit/hook/useIOC';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react';
+import { Link } from '@/i18n/routing';
 import { OAuthConsentGateway } from '@/impls/OAuthConsentGateway';
-import type { OAuthPlaygroundI18nInterface } from '@config/i18n-mapping/oauthPlaygroundI18n';
-import type {
-  OAuthClientDetail,
-  OAuthClientListItem
-} from '@schemas/oauth/OAuthAuthorizeSchema';
-import type { OAuthAuthorizePageData } from '@server/services/OAuthAuthorizeService';
-import { ROUTE_LOGIN, ROUTE_OAUTH_TOKEN, ROUTE_USERINFO } from '@config/route';
 import { readAppApiJson } from '@/pages/[locale]/developer/apps/readAppApiJson';
+import { usePageI18nMapping } from '@/uikit/context/PageI18nContext';
+import { useIOC } from '@/uikit/hook/useIOC';
+import { useUserAuth } from '@/uikit/hook/useUserAuth';
 import {
   buildAuthorizeUrl,
   parseOAuthCallbackUrl,
   randomStateValue,
   type OAuthCallbackParams
 } from '@/uikit/utils/oauthPlaygroundUtils';
+import type { OAuthPlaygroundI18nInterface } from '@config/i18n-mapping/oauthPlaygroundI18n';
+import { ROUTE_LOGIN, ROUTE_OAUTH_TOKEN, ROUTE_USERINFO } from '@config/route';
+import type {
+  OAuthClientDetail,
+  OAuthClientListItem
+} from '@schemas/oauth/OAuthAuthorizeSchema';
+import type { OAuthAuthorizePageData } from '@server/services/OAuthAuthorizeService';
 
 const labelClass =
   'text-secondary-text mb-1.5 block text-xs font-medium uppercase tracking-wide';
@@ -63,6 +69,7 @@ function PlaygroundAlert(props: {
 
   return (
     <div
+      data-testid="PlaygroundAlert"
       role="alert"
       className={clsx(
         'border-l-4 p-3 rounded-lg text-sm flex items-start gap-2',
@@ -101,7 +108,10 @@ function PlaygroundSection(props: {
   children: ReactNode;
 }) {
   return (
-    <section className="border-b border-primary-border last:border-b-0">
+    <section
+      data-testid="PlaygroundSection"
+      className="border-b border-primary-border last:border-b-0"
+    >
       <div className="flex items-center justify-between gap-3 px-5 sm:px-6 py-4 bg-elevated/50">
         <div className="flex items-center gap-3 min-w-0">
           <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-brand/10 text-brand text-sm font-semibold">
@@ -120,7 +130,10 @@ function PlaygroundSection(props: {
 
 function JsonBlock({ value }: { value: unknown }) {
   return (
-    <pre className="mt-2 max-h-64 overflow-auto rounded-lg bg-secondary border border-primary-border p-3 text-xs font-mono text-primary-text">
+    <pre
+      data-testid="JsonBlock"
+      className="mt-2 max-h-64 overflow-auto rounded-lg bg-secondary border border-primary-border p-3 text-xs font-mono text-primary-text"
+    >
       {JSON.stringify(value, null, 2)}
     </pre>
   );
@@ -257,9 +270,7 @@ export function OAuthPlayground() {
       );
       setValidateResult(result);
     } catch (err) {
-      setErrorMessage(
-        err instanceof Error ? err.message : 'Validation failed'
-      );
+      setErrorMessage(err instanceof Error ? err.message : 'Validation failed');
     } finally {
       setValidating(false);
     }
@@ -391,7 +402,7 @@ export function OAuthPlayground() {
     (tokenResponse as { body: { access_token?: string } }).body?.access_token;
 
   return (
-    <div className="flex flex-1 flex-col">
+    <div data-testid="OAuthPlayground" className="flex flex-1 flex-col">
       <div className="flex flex-1 items-start justify-center px-4 py-8 sm:py-12">
         <div
           data-testid="OAuthPlayground"
@@ -415,6 +426,7 @@ export function OAuthPlayground() {
             <div className="mt-6 flex flex-wrap gap-2">
               {stepTitles.map((title, index) => (
                 <span
+                  data-testid="OAuthPlayground"
                   key={title}
                   className={clsx(
                     'text-xs px-3 py-1 rounded-full border font-medium transition-colors',
@@ -443,8 +455,7 @@ export function OAuthPlayground() {
           <PlaygroundSection title={tt.stepSession} step={1}>
             {authLoading ? (
               <p className="text-secondary-text text-sm flex items-center gap-2">
-                <LoadingOutlined spin />
-                …
+                <LoadingOutlined spin />…
               </p>
             ) : success && user ? (
               <p className="text-primary-text text-sm flex items-center gap-2">
@@ -491,11 +502,13 @@ export function OAuthPlayground() {
                 value={clientId ?? ''}
                 onChange={(e) => setClientId(e.target.value)}
               >
-                {clients.length === 0 && (
-                  <option value="">—</option>
-                )}
+                {clients.length === 0 && <option value="">—</option>}
                 {clients.map((c) => (
-                  <option key={c.client_id} value={c.client_id}>
+                  <option
+                    data-testid="OAuthPlayground"
+                    key={c.client_id}
+                    value={c.client_id}
+                  >
                     {c.client_name} ({c.client_id})
                   </option>
                 ))}
@@ -518,7 +531,11 @@ export function OAuthPlayground() {
                     }}
                   >
                     {clientDetail.redirect_uris.map((uri) => (
-                      <option key={uri} value={uri}>
+                      <option
+                        data-testid="OAuthPlayground"
+                        key={uri}
+                        value={uri}
+                      >
                         {uri}
                       </option>
                     ))}
@@ -530,6 +547,7 @@ export function OAuthPlayground() {
                   <div className="space-y-2">
                     {clientDetail.scopes.map((scope) => (
                       <label
+                        data-testid="OAuthPlayground"
                         key={scope}
                         className="flex items-center gap-2 text-sm text-primary-text cursor-pointer"
                       >
@@ -581,7 +599,9 @@ export function OAuthPlayground() {
                 </button>
 
                 {validateResult?.valid && (
-                  <PlaygroundAlert variant="success">{tt.validOk}</PlaygroundAlert>
+                  <PlaygroundAlert variant="success">
+                    {tt.validOk}
+                  </PlaygroundAlert>
                 )}
                 {validateResult && !validateResult.valid && (
                   <PlaygroundAlert variant="error">
@@ -600,7 +620,10 @@ export function OAuthPlayground() {
                         readOnly
                         value={authorizeUrl}
                         rows={3}
-                        className={clsx(inputClass, 'font-mono text-xs resize-y')}
+                        className={clsx(
+                          inputClass,
+                          'font-mono text-xs resize-y'
+                        )}
                       />
                       <button
                         type="button"
@@ -627,9 +650,7 @@ export function OAuthPlayground() {
               <button
                 type="button"
                 className={primaryButtonClass}
-                disabled={
-                  !success || !validateResult?.valid || consentLoading
-                }
+                disabled={!success || !validateResult?.valid || consentLoading}
                 onClick={() => void submitConsent('allow')}
               >
                 {consentLoading && <LoadingOutlined spin />}
@@ -638,9 +659,7 @@ export function OAuthPlayground() {
               <button
                 type="button"
                 className={secondaryButtonClass}
-                disabled={
-                  !success || !validateResult?.valid || consentLoading
-                }
+                disabled={!success || !validateResult?.valid || consentLoading}
                 onClick={() => void submitConsent('deny')}
               >
                 {tt.deny}

--- a/examples/brain-oauth/src/uikit/components/LocaleLink.tsx
+++ b/examples/brain-oauth/src/uikit/components/LocaleLink.tsx
@@ -5,8 +5,7 @@ import type { LinkProps } from 'next/link';
 import type { ReactNode } from 'react';
 
 interface LocaleLinkProps
-  extends
-    Omit<LinkProps, 'href'>,
+  extends Omit<LinkProps, 'href'>,
     Omit<React.HTMLAttributes<HTMLAnchorElement>, 'children'> {
   href:
     | string

--- a/examples/brain-oauth/src/uikit/components/LoginForm.tsx
+++ b/examples/brain-oauth/src/uikit/components/LoginForm.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { type FormEvent, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { type FormEvent, useMemo, useState } from 'react';
+import { BrainAuthGateway } from '@/impls/BrainAuthGateway';
 import { LocaleLink } from '@/uikit/components/LocaleLink';
 import { useIOC } from '@/uikit/hook/useIOC';
 import { useWarnTranslations } from '@/uikit/hook/useWarnTranslations';
-import { BrainAuthGateway } from '@/impls/BrainAuthGateway';
 import { LoginValidator } from '@shared/validators/LoginValidator';
 import type { LoginI18nInterface } from '@config/i18n-mapping/loginI18n';
 import { I } from '@config/ioc-identifiter';
@@ -13,52 +13,8 @@ import { ROUTE_DASHBOARD_APPS, ROUTE_REGISTER } from '@config/route';
 import type { LoginSchema } from '@schemas/LoginSchema';
 import type { SeedSrcConfigInterface } from '@interfaces/SeedConfigInterface';
 
-function IconGoogle() {
-  return (
-    <svg
-      data-testid="LoginForm-icon-google"
-      className="h-5 w-5"
-      viewBox="0 0 24 24"
-      aria-hidden
-    >
-      <path
-        fill="#4285F4"
-        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-      />
-      <path
-        fill="#34A853"
-        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-      />
-      <path
-        fill="#FBBC05"
-        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-      />
-      <path
-        fill="#EA4335"
-        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-      />
-    </svg>
-  );
-}
-
-function IconGitHub() {
-  return (
-    <svg
-      data-testid="LoginForm-icon-github"
-      className="h-5 w-5"
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden
-    >
-      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-    </svg>
-  );
-}
-
 const inputClass =
   'border-primary-border text-primary-text placeholder:text-tertiary-text focus:border-brand focus:ring-brand w-full rounded-xl border bg-bg-container px-4 py-3 text-sm outline-none transition-colors focus:ring-2 focus:ring-offset-0';
-const socialBtnClass =
-  'border-primary-border bg-bg-container text-primary-text hover:bg-secondary focus:ring-brand inline-flex w-full items-center justify-center gap-3 rounded-xl border px-4 py-3 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-0';
 
 export function LoginForm(props: { tt: LoginI18nInterface }) {
   const { tt } = props;

--- a/examples/brain-oauth/src/uikit/utils/oauthPlaygroundUtils.ts
+++ b/examples/brain-oauth/src/uikit/utils/oauthPlaygroundUtils.ts
@@ -48,7 +48,9 @@ export function buildAuthorizeUrl(
 /**
  * Parses code / error from the redirect URL returned by consent (no browser navigation).
  */
-export function parseOAuthCallbackUrl(redirectUrl: string): OAuthCallbackParams {
+export function parseOAuthCallbackUrl(
+  redirectUrl: string
+): OAuthCallbackParams {
   const url = new URL(redirectUrl);
   return {
     code: url.searchParams.get('code') ?? undefined,


### PR DESCRIPTION
- Added `record_type` column to `request_logs` table for categorizing log entries.
- Updated `NextApiServer` to include `record_type` in log events.
- Introduced utility functions to resolve log record types based on request paths.
- Modified `RequestLogsRepository` and related interfaces to accommodate the new `record_type`.
- Created new utility functions for logging OAuth-related requests.

These changes improve the granularity of request logging, allowing for better tracking and analysis of OAuth-related traffic.