### PR TITLE
feat(brain-oauth): Rename dashboard apps route to developer apps

### DIFF
--- a/examples/brain-oauth/shared/config/route.ts
+++ b/examples/brain-oauth/shared/config/route.ts
@@ -18,7 +18,7 @@ export const ROUTE_REQUEST_LOGS = '/admin/request-logs' as const;
 export const ROUTE_HOME = '/' as const;
 
 /** Developer console app list (PRD default post-login redirect). */
-export const ROUTE_DASHBOARD_APPS = '/dashboard/apps' as const;
+export const ROUTE_DEVELOPER_APPS = '/developer/apps' as const;
 
 /** OAuth 2.0 authorization consent page. */
 export const ROUTE_OAUTH_AUTHORIZE = '/oauth/authorize' as const;

--- a/examples/brain-oauth/src/i18n/routing.ts
+++ b/examples/brain-oauth/src/i18n/routing.ts
@@ -3,7 +3,7 @@ import { defineRouting } from 'next-intl/routing';
 import { useLocaleRoutes } from '@config/common';
 import { i18nConfig } from '@config/i18n';
 import {
-  ROUTE_DASHBOARD_APPS,
+  ROUTE_DEVELOPER_APPS,
   ROUTE_LOGIN,
   ROUTE_OAUTH_AUTHORIZE,
   ROUTE_OAUTH_PLAYGROUND,
@@ -39,9 +39,9 @@ export const routing = defineRouting({
       en: '/admin/request-logs',
       zh: '/admin/request-logs'
     },
-    [ROUTE_DASHBOARD_APPS]: {
-      en: '/dashboard/apps',
-      zh: '/dashboard/apps'
+    [ROUTE_DEVELOPER_APPS]: {
+      en: '/developer/apps',
+      zh: '/developer/apps'
     },
     [ROUTE_OAUTH_AUTHORIZE]: {
       en: '/oauth/authorize',

--- a/examples/brain-oauth/src/uikit/components-app/home/HomeSections.tsx
+++ b/examples/brain-oauth/src/uikit/components-app/home/HomeSections.tsx
@@ -11,7 +11,7 @@ import { clsx } from 'clsx';
 import { Link } from '@/i18n/routing';
 import { API_REFERENCE } from '@config/apiRoutes';
 import type { HomeI18nInterface } from '@config/i18n-mapping/HomeI18n';
-import { ROUTE_DASHBOARD_APPS, ROUTE_REGISTER } from '@config/route';
+import { ROUTE_DEVELOPER_APPS, ROUTE_REGISTER } from '@config/route';
 
 const primaryButtonClassName =
   'inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-brand text-on-brand font-medium hover:bg-brand-hover transition shadow-md';
@@ -124,7 +124,7 @@ export function HomeCta({ tt }: HomeSectionProps) {
       </h2>
       <p className="text-secondary-text mb-6">{tt.ctaDesc}</p>
       <Link
-        href={ROUTE_DASHBOARD_APPS}
+        href={ROUTE_DEVELOPER_APPS}
         className={clsx(
           primaryButtonClassName,
           'px-5 py-2.5 text-sm font-medium'

--- a/examples/brain-oauth/src/uikit/components/LoginForm.tsx
+++ b/examples/brain-oauth/src/uikit/components/LoginForm.tsx
@@ -9,7 +9,7 @@ import { useWarnTranslations } from '@/uikit/hook/useWarnTranslations';
 import { LoginValidator } from '@shared/validators/LoginValidator';
 import type { LoginI18nInterface } from '@config/i18n-mapping/loginI18n';
 import { I } from '@config/ioc-identifiter';
-import { ROUTE_DASHBOARD_APPS, ROUTE_REGISTER } from '@config/route';
+import { ROUTE_DEVELOPER_APPS, ROUTE_REGISTER } from '@config/route';
 import type { LoginSchema } from '@schemas/LoginSchema';
 import type { SeedSrcConfigInterface } from '@interfaces/SeedConfigInterface';
 
@@ -73,7 +73,7 @@ export function LoginForm(props: { tt: LoginI18nInterface }) {
       const redirectTarget =
         searchParams?.get('redirect') ??
         searchParams?.get('returnUrl') ??
-        ROUTE_DASHBOARD_APPS;
+        ROUTE_DEVELOPER_APPS;
 
       if (redirectTarget.startsWith('http')) {
         window.location.href = redirectTarget;


### PR DESCRIPTION
- Updated the route constant from `ROUTE_DASHBOARD_APPS` to `ROUTE_DEVELOPER_APPS` for better clarity.
- Adjusted related imports and references across routing and UI components to reflect the new naming convention.
- Ensured consistency in localization for the updated route.

These changes enhance the clarity of the routing structure, aligning it with the intended functionality of the application.